### PR TITLE
Develop

### DIFF
--- a/bitcast/validator/README.md
+++ b/bitcast/validator/README.md
@@ -65,6 +65,8 @@ Ensure your machine meets these requirements before proceeding with setup.
    - `RAPID_API_KEY`: Your RapidAPI key
    - `OPENAI_API_KEY`: Your OpenAI API key
    - `WANDB_API_KEY`: Your Weights & Biases API key
+   - `VENV_PATH`: (Optional) Custom path to Python virtual environment
+   - `PM2_PROCESS_NAME`: (Optional) Custom name for PM2 process (default: bitcast_validator)
 
 4. **Register on Bittensor Network**
    ```bash

--- a/bitcast/validator/socials/youtube/youtube_evaluation.py
+++ b/bitcast/validator/socials/youtube/youtube_evaluation.py
@@ -81,7 +81,7 @@ def vet_videos(video_ids, briefs, youtube_data_client, youtube_analytics_client)
             cached_data = youtube_utils.youtube_cache.get_video_cache(video_id)
             if cached_data:
                 # If cached data exists and publishDateCheck failed last time, use cached data
-                if not cached_data.get("decision_details", {}).get("publishDateCheck", True):
+                if cached_data.get("decision_details", {}).get("publishDateCheck") is False:
                     bt.logging.info(f"Using cached data (failed publishDateCheck)")
                     results[video_id] = cached_data["results"]
                     video_data_dict[video_id] = cached_data["video_data"]

--- a/bitcast/validator/utils/briefs.py
+++ b/bitcast/validator/utils/briefs.py
@@ -80,9 +80,10 @@ def get_briefs(all: bool = False):
                 try:
                     start_date = datetime.strptime(brief["start_date"], "%Y-%m-%d").date()
                     end_date = datetime.strptime(brief["end_date"], "%Y-%m-%d").date()
+                    start_date_with_delay = start_date + timedelta(days=YT_REWARD_DELAY)
                     end_date_with_delay = end_date + timedelta(days=YT_REWARD_DELAY)
                     
-                    if start_date <= current_date <= end_date_with_delay:
+                    if start_date_with_delay <= current_date <= end_date_with_delay:
                         filtered_briefs.append(brief)
                 except Exception as e:
                     bt.logging.error(f"Error parsing dates for brief {brief.get('id', 'unknown')}: {e}")

--- a/bitcast/validator/utils/config.py
+++ b/bitcast/validator/utils/config.py
@@ -15,7 +15,7 @@ CACHE_DIRS = {
     "briefs": os.path.join(CACHE_ROOT, "briefs")
 }
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # required
 BITCAST_SERVER_URL = os.getenv('BITCAST_SERVER_URL', 'http://44.227.253.127')

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -29,7 +29,13 @@ fi
 # Virtual Environment Setup #
 ############################
 
-VENV_PATH="$PROJECT_PARENT/venv_bitcast"
+# Load environment variables from .env file if it exists
+if [ -f "$PROJECT_ROOT/bitcast/validator/.env" ]; then
+  export $(grep -v '^#' "$PROJECT_ROOT/bitcast/validator/.env" | sed 's/ *= */=/g' | xargs)
+fi
+
+# Set default virtual environment path if not specified in .env
+VENV_PATH=${VENV_PATH:-"$PROJECT_PARENT/venv_bitcast"}
 
 # Create virtual environment if it doesn't exist
 if [ ! -d "$VENV_PATH" ]; then

--- a/tests/validator/test_briefs.py
+++ b/tests/validator/test_briefs.py
@@ -41,13 +41,17 @@ def test_get_briefs_all(monkeypatch):
 def test_get_briefs_active(monkeypatch):
     """
     Test that get_briefs correctly filters briefs based on active dates when 'all' is False.
-    Only briefs whose start_date and end_date include the current date should be returned.
+    Only briefs whose delayed start_date and end_date include the current date should be returned.
     """
     current_date = datetime.now(timezone.utc).date()
-    current_date_str = current_date.strftime("%Y-%m-%d")
+    # Set start date to be YT_REWARD_DELAY days before current date
+    start_date = current_date - timedelta(days=YT_REWARD_DELAY)
+    # Set end date to be current date
+    end_date = current_date
+    
     mock_data = {
         "briefs": [
-            {"id": "active", "start_date": current_date_str, "end_date": current_date_str},
+            {"id": "active", "start_date": start_date.strftime("%Y-%m-%d"), "end_date": end_date.strftime("%Y-%m-%d")},
             {"id": "inactive", "start_date": "2000-01-01", "end_date": "2000-01-02"}
         ]
     }


### PR DESCRIPTION
Release Notes — v1.1.1

This patch focuses on tightening control over caching behavior and configuration flexibility, while refining emissions logic.

Bug Fixes

Ensured cached video data is only used when publishDateCheck is explicitly disabled, preventing stale data usage.

Emissions from new briefs now respect the delay period before impacting calculations.

Enhancements

Added optional environment variables to configure validator PM2 process name and virtual environment path.