### PR TITLE
V 1.4.2 (#36)

### DIFF
--- a/bitcast/validator/rewards_scaling.py
+++ b/bitcast/validator/rewards_scaling.py
@@ -36,7 +36,7 @@ def calculate_brief_emissions_scalar(yt_stats_list: List[dict], briefs: List[dic
                             if not decision_details.get("video_vet_result", False):
                                 continue
 
-                            minutes = float(video_data.get("analytics", {}).get("estimatedMinutesWatched", 0))
+                            minutes = float(video_data.get("analytics", {}).get("minutes_watched_w_lag", 0))
                             scorable_proportion = float(video_data.get("analytics", {}).get("scorable_proportion", 0))
                             
                             matching_briefs = video_data.get("matching_brief_ids", [])

--- a/bitcast/validator/socials/youtube/config.py
+++ b/bitcast/validator/socials/youtube/config.py
@@ -1,0 +1,70 @@
+"""
+YouTube analytics metrics and configuration.
+
+This file contains configurations for different types of YouTube analytics metrics
+used for evaluating and scoring videos.
+"""
+
+# Core metrics for general analytics
+CORE_METRICS = {
+    "averageViewPercentage": ("averageViewPercentage", ""),
+    "estimatedMinutesWatched": ("estimatedMinutesWatched", ""),
+    "trafficSourceMinutes": ("estimatedMinutesWatched", "insightTrafficSourceType"),
+}
+
+# Additional metrics for full analytics (when not in ECO_MODE)
+ADDITIONAL_METRICS = {
+    "views": ("views", ""),
+    "comments": ("comments", ""),
+    "likes": ("likes", ""),
+    "dislikes": ("dislikes", ""),
+    "shares": ("shares", ""),
+    "averageViewDuration": ("averageViewDuration", ""),
+    "countryMinutes": ("estimatedMinutesWatched", "country"),
+    "ageGroupViewerPercentage": ("viewerPercentage", "ageGroup,gender"),
+    "elapsedVideoTimeRatioAudienceWatchRatio": ("audienceWatchRatio", "elapsedVideoTimeRatio"),
+    "sharingServiceShares": ("shares", "sharingService")
+}
+
+# Core daily metrics - all metrics with day dimension
+CORE_DAILY_METRICS = {
+    "estimatedMinutesWatched": ("estimatedMinutesWatched", "day"),
+}
+
+# Additional daily metrics for ECO_MODE
+ADDITIONAL_DAILY_METRICS = {
+    "views": ("views", "day"),
+    "comments": ("comments", "day"),
+    "likes": ("likes", "day"),
+    "shares": ("shares", "day"),
+    "averageViewDuration": ("averageViewDuration", "day"),
+    "AverageViewPercentage": ("averageViewPercentage", "day"),
+    "trafficSourceMinutes": ("estimatedMinutesWatched", "insightTrafficSourceType,day"),
+    "deviceTypeMinutes": ("estimatedMinutesWatched", "deviceType,day"),
+    "operatingSystemMinutes": ("estimatedMinutesWatched", "operatingSystem,day"),
+    "creatorContentTypeMinutes": ("estimatedMinutesWatched", "creatorContentType,day"),
+    "playbackLocationMinutes": ("estimatedMinutesWatched", "insightPlaybackLocationType,day"),
+    "avgViewPercentageByTrafficSource": ("averageViewPercentage", "insightTrafficSourceType,day"),
+    "liveOrOnDemandMinutes": ("estimatedMinutesWatched", "liveOrOnDemand,day"),
+    "youtubeProductMinutes": ("estimatedMinutesWatched", "youtubeProduct,day"),
+}
+
+def get_youtube_metrics(eco_mode, for_daily=False):
+    """
+    Get the appropriate YouTube metrics configuration based on context.
+    
+    Args:
+        for_daily: Whether to get daily metrics (True) or general metrics (False)
+        eco_mode: Whether to use ECO_MODE metrics (reduced set)
+        
+    Returns:
+        Dictionary of metric dimensions for YouTube API calls
+    """
+    if for_daily and eco_mode:
+        return CORE_DAILY_METRICS
+    elif for_daily and not eco_mode:
+        return {**CORE_DAILY_METRICS, **ADDITIONAL_DAILY_METRICS}
+    elif not for_daily and eco_mode:
+        return {**CORE_METRICS}
+    else:
+        return {**CORE_METRICS, **ADDITIONAL_METRICS}

--- a/bitcast/validator/socials/youtube/youtube_scoring.py
+++ b/bitcast/validator/socials/youtube/youtube_scoring.py
@@ -179,6 +179,7 @@ def update_video_score(video_id, youtube_analytics_client, video_matches, briefs
     
     result["videos"][video_id]["raw_score"] = video_score
     result["videos"][video_id]["score"] = scaled_score
+    result["videos"][video_id]["analytics"]["minutes_watched_w_lag"] = video_score_result["minutes_watched_w_lag"]
     result["videos"][video_id]["daily_analytics"] = video_score_result["daily_analytics"]
     
     # Update the score for the matching brief

--- a/bitcast/validator/socials/youtube/youtube_utils.py
+++ b/bitcast/validator/socials/youtube/youtube_utils.py
@@ -30,12 +30,12 @@ def reset_scored_videos():
     """
     global scored_video_ids
     scored_video_ids = []
-    bt.logging.info(f"Reset scored_video_ids list")
+    bt.logging.info("Reset scored_video_ids")
 
 def is_video_already_scored(video_id):
     """Check if a video has already been scored by another hotkey."""
     if video_id in scored_video_ids:
-        bt.logging.info(f"Video already scored by another hotkey")
+        bt.logging.info("Video already scored")
         return True
     return False
 
@@ -48,234 +48,179 @@ def mark_video_as_scored(video_id):
 # ============================================================================
 
 @retry(**YT_API_RETRY_CONFIG)
+def _query(client, start_date, end_date, metric, dimensions=None, filters=None):
+    params = {
+        'ids': 'channel==MINE',
+        'startDate': start_date,
+        'endDate': end_date,
+        'metrics': metric
+    }
+    if dimensions:
+        params['dimensions'] = dimensions
+    if filters:
+        params['filters'] = filters
+    resp = client.reports().query(**params).execute()
+    rows = resp.get("rows") or []
+    if not rows:
+        return {} if dimensions else []
+    
+    if not dimensions:
+        # Return the row directly for non-dimensional queries
+        return rows[0]
+        
+    # For dimensional queries, create a dictionary
+    data = {}
+    for row in rows:
+        dims, val = row[:-1], row[-1]
+        key = "|".join(str(d) for d in dims) if len(dims) > 1 else str(dims[0])
+        data[key] = val
+    return data
+
+@retry(**YT_API_RETRY_CONFIG)
+def _query_multiple_metrics(client, start_date, end_date, metrics_list, dimensions=None, filters=None):
+    """Query multiple metrics in a single API call and return split results.
+    
+    Args:
+        client: YouTube Analytics client
+        start_date: Start date for query
+        end_date: End date for query
+        metrics_list: List of metric names to fetch
+        dimensions: Dimensions for the query
+        filters: Filters for the query
+        
+    Returns:
+        Dictionary with metric names as keys and their respective results as values
+    """
+    metrics_str = ",".join(metrics_list)
+    params = {
+        'ids': 'channel==MINE',
+        'startDate': start_date,
+        'endDate': end_date,
+        'metrics': metrics_str
+    }
+    if dimensions:
+        params['dimensions'] = dimensions
+    if filters:
+        params['filters'] = filters
+    
+    resp = client.reports().query(**params).execute()
+    rows = resp.get("rows") or []
+    if not rows:
+        return {metric: ({} if dimensions else []) for metric in metrics_list}
+    
+    results = {}
+    
+    if not dimensions:
+        # For non-dimensional queries, return values by index
+        for i, metric in enumerate(metrics_list):
+            results[metric] = rows[0][i] if i < len(rows[0]) else 0
+    else:
+        # For dimensional queries, create dictionaries for each metric
+        for metric in metrics_list:
+            results[metric] = {}
+        
+        for row in rows:
+            # Split dimensions and metric values
+            num_dims = len(dimensions.split(",")) if dimensions else 0
+            dims, vals = row[:num_dims], row[num_dims:]
+            
+            # Create dimension key
+            key = "|".join(str(d) for d in dims) if len(dims) > 1 else str(dims[0])
+            
+            # Assign each metric value
+            for i, metric in enumerate(metrics_list):
+                if i < len(vals):
+                    results[metric][key] = vals[i]
+    
+    return results
+
+@retry(**YT_API_RETRY_CONFIG)
 def get_channel_data(youtube_data_client, discrete_mode=False):
     """Get basic channel information."""
-    account_info = youtube_data_client.channels().list(
+    resp = youtube_data_client.channels().list(
         part="snippet,contentDetails,statistics",
         mine=True
     ).execute()
-
-    channel_id = account_info['items'][0]['id']
-    if discrete_mode:
-        bitcast_channel_id = "bitcast_" + hashlib.sha256(channel_id.encode()).hexdigest()[:8]
-    else:
-        bitcast_channel_id = channel_id
-
-    channel_info = {
-        "title": account_info['items'][0]['snippet']['title'],
-        "id": channel_id,
-        "bitcastChannelId": bitcast_channel_id,
-        "channel_start": account_info['items'][0]['snippet']['publishedAt'],
-        "viewCount": account_info['items'][0]['statistics']['viewCount'],
-        "subCount": account_info['items'][0]['statistics']['subscriberCount'],
-        "videoCount": account_info['items'][0]['statistics']['videoCount'],
-        "url": f"https://www.youtube.com/channel/{channel_id}"
+    item = resp['items'][0]
+    cid = item['id']
+    bcid = ("bitcast_" + hashlib.sha256(cid.encode()).hexdigest()[:8]) if discrete_mode else cid
+    return {
+        "title": item['snippet']['title'],
+        "id": cid,
+        "bitcastChannelId": bcid,
+        "channel_start": item['snippet']['publishedAt'],
+        "viewCount": item['statistics']['viewCount'],
+        "subCount": item['statistics']['subscriberCount'],
+        "videoCount": item['statistics']['videoCount'],
+        "url": f"https://www.youtube.com/channel/{cid}"
     }
-
-    return channel_info
 
 @retry(**YT_API_RETRY_CONFIG)
 def get_channel_analytics(youtube_analytics_client, start_date, end_date=None, dimensions=""):
     """Get comprehensive channel analytics including traffic sources."""
-    if end_date is None:
-        end_date = datetime.today().strftime('%Y-%m-%d')
-        
-    # Define metrics in a consistent order
-    metrics_list = "views,comments,likes,dislikes,shares,averageViewDuration,averageViewPercentage,subscribersGained,subscribersLost,estimatedMinutesWatched"
-    
-    analytics_response = youtube_analytics_client.reports().query(
+    end = end_date or datetime.today().strftime('%Y-%m-%d')
+    metrics = ",".join([
+        "views","comments","likes","dislikes","shares",
+        "averageViewDuration","averageViewPercentage",
+        "subscribersGained","subscribersLost","estimatedMinutesWatched"
+    ])
+    resp = youtube_analytics_client.reports().query(
         ids="channel==MINE",
         startDate=start_date,
-        endDate=end_date,
+        endDate=end,
         dimensions=dimensions,
-        metrics=metrics_list
-        ).execute()
-
-    if not analytics_response.get("rows"):
+        metrics=metrics
+    ).execute()
+    rows = resp.get("rows")
+    if not rows:
         raise Exception("No channel analytics data found.")
-
-    # Define metric names in the same order as the metrics_list
-    metric_names = [
-        "views", "comments", "likes", "dislikes", "shares", 
-        "averageViewDuration", "averageViewPercentage", 
-        "subscribersGained", "subscribersLost", "estimatedMinutesWatched"
-    ]
-
+    names = metrics.split(",")
     if dimensions:
-        # Handle the case where dimensions are present
-        analytics_info = []
-        for row in analytics_response.get("rows", []):
-            dimension_values = row[:len(dimensions.split(','))]
-            metrics = dict(zip(metric_names, row[len(dimension_values):]))
-            for i, dimension in enumerate(dimensions.split(',')):
-                metrics[dimension] = dimension_values[i]
-            analytics_info.append(metrics)
+        info = []
+        dims_keys = dimensions.split(",")
+        for row in rows:
+            dims, vals = row[:len(dims_keys)], row[len(dims_keys):]
+            entry = dict(zip(names, vals))
+            for i, d in enumerate(dims_keys):
+                entry[d] = dims[i]
+            info.append(entry)
     else:
-        # Handle the case where no dimensions are present
-        analytics_data = analytics_response["rows"][0]
-        analytics_info = dict(zip(metric_names, analytics_data))
+        info = dict(zip(names, rows[0]))
 
-    # Get traffic source data for views
-    traffic_source_views = get_traffic_source_views_analytics(youtube_analytics_client, start_date, end_date)
-    # Get traffic source data for minutes watched
-    traffic_source_minutes = get_traffic_source_minutes_analytics(youtube_analytics_client, start_date, end_date)
-    # Get country data for views
-    country_views = get_country_views_analytics(youtube_analytics_client, start_date, end_date)
-    # Get country data for minutes watched
-    country_minutes = get_country_minutes_analytics(youtube_analytics_client, start_date, end_date)
+    # Consolidate API calls for traffic source data
+    traffic_data = _query_multiple_metrics(
+        youtube_analytics_client, start_date, end, 
+        ["views", "estimatedMinutesWatched"], 
+        "insightTrafficSourceType"
+    )
     
-    # Get subscribers gained including 30 days prior if dimensions is "day"
-    if dimensions == "day":
-        past_date = (datetime.strptime(start_date, '%Y-%m-%d') - timedelta(days=30)).strftime('%Y-%m-%d')
-    else:
-        past_date = start_date
-    subscribers_gained = get_subscribers_gained_analytics(youtube_analytics_client, past_date, end_date)
+    # Consolidate API calls for country data
+    country_data = _query_multiple_metrics(
+        youtube_analytics_client, start_date, end,
+        ["views", "estimatedMinutesWatched"],
+        "country"
+    )
     
-    if isinstance(analytics_info, dict):
-        analytics_info["trafficSourceViews"] = traffic_source_views
-        analytics_info["trafficSourceMinutes"] = traffic_source_minutes
-        analytics_info["countryViews"] = country_views
-        analytics_info["countryMinutes"] = country_minutes
-        analytics_info["subscribersGained"] = subscribers_gained
+    # Keep subscriber data separate due to different date range
+    past = (
+        (datetime.strptime(start_date, '%Y-%m-%d') - timedelta(days=30)).strftime('%Y-%m-%d')
+        if dimensions == "day" else start_date
+    )
+    subs = _query(youtube_analytics_client, past, end, "subscribersGained", "day")
+
+    extras = {
+        "trafficSourceViews":   traffic_data["views"],
+        "trafficSourceMinutes": traffic_data["estimatedMinutesWatched"],
+        "countryViews":         country_data["views"],
+        "countryMinutes":       country_data["estimatedMinutesWatched"],
+        "subscribersGained":    subs
+    }
+    if isinstance(info, dict):
+        info.update(extras)
     else:
-        for entry in analytics_info:
-            entry["trafficSourceViews"] = traffic_source_views
-            entry["trafficSourceMinutes"] = traffic_source_minutes
-            entry["countryViews"] = country_views
-            entry["countryMinutes"] = country_minutes
-            entry["subscribersGained"] = subscribers_gained
-
-    return analytics_info
-
-@retry(**YT_API_RETRY_CONFIG)
-def get_traffic_source_views_analytics(youtube_analytics_client, start_date, end_date):
-    """Get traffic source analytics for views."""
-    try:
-        traffic_response = youtube_analytics_client.reports().query(
-            ids="channel==MINE",
-            startDate=start_date,
-            endDate=end_date,
-            dimensions="insightTrafficSourceType",
-            metrics="views"
-        ).execute()
-
-        if not traffic_response.get("rows"):
-            return {}
-
-        traffic_sources = {}
-        for row in traffic_response.get("rows", []):
-            source_type = row[0]
-            views = row[1]
-            traffic_sources[source_type] = views
-
-        return traffic_sources
-    except Exception as e:
-        bt.logging.warning(f"Error getting traffic source views analytics: {_format_error(e)}")
-        return {}
-
-@retry(**YT_API_RETRY_CONFIG)
-def get_traffic_source_minutes_analytics(youtube_analytics_client, start_date, end_date):
-    """Get traffic source analytics for minutes watched."""
-    try:
-        traffic_response = youtube_analytics_client.reports().query(
-            ids="channel==MINE",
-            startDate=start_date,
-            endDate=end_date,
-            dimensions="insightTrafficSourceType",
-            metrics="estimatedMinutesWatched"
-        ).execute()
-
-        if not traffic_response.get("rows"):
-            return {}
-
-        traffic_sources = {}
-        for row in traffic_response.get("rows", []):
-            source_type = row[0]
-            minutes = row[1]
-            traffic_sources[source_type] = minutes
-
-        return traffic_sources
-    except Exception as e:
-        bt.logging.warning(f"Error getting traffic source minutes analytics: {_format_error(e)}")
-        return {}
-
-@retry(**YT_API_RETRY_CONFIG)
-def get_country_views_analytics(youtube_analytics_client, start_date, end_date):
-    """Get views analytics by country."""
-    try:
-        country_response = youtube_analytics_client.reports().query(
-            ids="channel==MINE",
-            startDate=start_date,
-            endDate=end_date,
-            dimensions="country",
-            metrics="views"
-        ).execute()
-
-        if not country_response.get("rows"):
-            return {}
-
-        country_data = {}
-        for row in country_response.get("rows", []):
-            country_code = row[0]
-            views = row[1]
-            country_data[country_code] = views
-
-        return country_data
-    except Exception as e:
-        bt.logging.warning(f"Error getting country views analytics: {_format_error(e)}")
-        return {}
-
-@retry(**YT_API_RETRY_CONFIG)
-def get_country_minutes_analytics(youtube_analytics_client, start_date, end_date):
-    """Get minutes watched analytics by country."""
-    try:
-        country_response = youtube_analytics_client.reports().query(
-            ids="channel==MINE",
-            startDate=start_date,
-            endDate=end_date,
-            dimensions="country",
-            metrics="estimatedMinutesWatched"
-        ).execute()
-
-        if not country_response.get("rows"):
-            return {}
-
-        country_data = {}
-        for row in country_response.get("rows", []):
-            country_code = row[0]
-            minutes = row[1]
-            country_data[country_code] = minutes
-
-        return country_data
-    except Exception as e:
-        bt.logging.warning(f"Error getting country minutes analytics: {_format_error(e)}")
-        return {}
-
-@retry(**YT_API_RETRY_CONFIG)
-def get_subscribers_gained_analytics(youtube_analytics_client, start_date, end_date):
-    """Get subscribers gained analytics by day."""
-    try:
-        subscribers_response = youtube_analytics_client.reports().query(
-            ids="channel==MINE",
-            startDate=start_date,
-            endDate=end_date,
-            dimensions="day",
-            metrics="subscribersGained"
-        ).execute()
-
-        if not subscribers_response.get("rows"):
-            return {}
-
-        subscribers_data = {}
-        for row in subscribers_response.get("rows", []):
-            date = row[0]
-            subscribers = row[1]
-            subscribers_data[date] = subscribers
-
-        return subscribers_data
-    except Exception as e:
-        bt.logging.warning(f"Error getting subscribers gained analytics: {_format_error(e)}")
-        return {}
+        for entry in info:
+            entry.update(extras)
+    return info
 
 # ============================================================================
 # Video Playlist and List Management
@@ -284,54 +229,42 @@ def get_subscribers_gained_analytics(youtube_analytics_client, start_date, end_d
 @retry(**YT_API_RETRY_CONFIG)
 def get_uploads_playlist_id(youtube):
     """Retrieve the channel's uploads playlist id."""
-    channels_response = youtube.channels().list(
-        mine=True,
-        part="contentDetails"
-    ).execute()
-
-    if not channels_response["items"]:
+    resp = youtube.channels().list(mine=True, part="contentDetails").execute()
+    items = resp.get("items") or []
+    if not items:
         raise Exception("No channel found for the authenticated user.")
-        
-    uploads_playlist_id = channels_response["items"][0]["contentDetails"]["relatedPlaylists"]["uploads"]
-    return uploads_playlist_id
+    return items[0]["contentDetails"]["relatedPlaylists"]["uploads"]
 
 @retry(**YT_API_RETRY_CONFIG)
 def list_all_videos(youtube, uploads_playlist_id):
     """List all videos in the uploads playlist."""
-    videos = []
-    nextPageToken = None
-
+    all_items, token = [], None
     while True:
-        playlist_response = youtube.playlistItems().list(
+        resp = youtube.playlistItems().list(
             playlistId=uploads_playlist_id,
             part="snippet",
             maxResults=50,
-            pageToken=nextPageToken
+            pageToken=token
         ).execute()
-        videos.extend(playlist_response.get("items", []))
-        nextPageToken = playlist_response.get("nextPageToken")
-        if not nextPageToken:
+        all_items.extend(resp.get("items", []))
+        token = resp.get("nextPageToken")
+        if not token:
             break
-    return videos
+    return all_items
 
 @retry(**YT_API_RETRY_CONFIG)
 def get_all_uploads(youtube_data_client, max_age_days=365):
     """Get all video IDs uploaded within the specified time period."""
-    uploads_playlist_id = get_uploads_playlist_id(youtube_data_client)
-    videos = list_all_videos(youtube_data_client, uploads_playlist_id)
-
-    cutoff_date = datetime.utcnow() - timedelta(days=max_age_days)
-    video_ids = []
-    for video in videos:
-        snippet = video["snippet"]
-        published_at = datetime.strptime(
-            snippet["publishedAt"], "%Y-%m-%dT%H:%M:%SZ"
-        )
-        if published_at >= cutoff_date:
-            video_ids.append(snippet["resourceId"]["videoId"])
-
-    bt.logging.info(f"Found {len(video_ids)} videos uploaded in the last {max_age_days} days")
-    return video_ids
+    pid = get_uploads_playlist_id(youtube_data_client)
+    videos = list_all_videos(youtube_data_client, pid)
+    cutoff = datetime.utcnow() - timedelta(days=max_age_days)
+    vids = []
+    for v in videos:
+        pub = datetime.strptime(v["snippet"]["publishedAt"], "%Y-%m-%dT%H:%M:%SZ")
+        if pub >= cutoff:
+            vids.append(v["snippet"]["resourceId"]["videoId"])
+    bt.logging.info(f"Found {len(vids)} videos uploaded in the last {max_age_days} days")
+    return vids
 
 # ============================================================================
 # Video Analytics Functions
@@ -340,243 +273,172 @@ def get_all_uploads(youtube_data_client, max_age_days=365):
 @retry(**YT_API_RETRY_CONFIG)
 def get_video_data(youtube_data_client, video_id, discrete_mode=False):
     """Get basic video information."""
-    video_response = youtube_data_client.videos().list(
+    resp = youtube_data_client.videos().list(
         part="snippet,statistics,contentDetails,status",
         id=video_id
     ).execute()
-
-    if not video_response["items"]:
-        raise Exception(f"No video found with matching ID")
-
-    if discrete_mode:
-        bitcast_video_id = "bitcast_" + hashlib.sha256(video_id.encode()).hexdigest()[:8]
-    else:
-        bitcast_video_id = video_id
-
-    video_info = video_response["items"][0]
-    stats = {
-        "videoId": video_id,
-        "bitcastVideoId": bitcast_video_id,
-        "title": video_info["snippet"]["title"],
-        "description": video_info["snippet"]["description"],
-        "publishedAt": video_info["snippet"]["publishedAt"],
-        "viewCount": video_info["statistics"].get("viewCount", 0),
-        "likeCount": video_info["statistics"].get("likeCount", 0),
-        "commentCount": video_info["statistics"].get("commentCount", 0),
-        "duration": video_info["contentDetails"]["duration"],
-        "caption": video_info["contentDetails"]["caption"].lower() == "true",
-        "privacyStatus": video_info["status"]["privacyStatus"]
-    }
-
-    return stats
-
-@retry(**YT_API_RETRY_CONFIG)
-def get_video_analytics(youtube_analytics_client, video_id, start_date=None, end_date=None, dimensions=""):
-    """Get comprehensive video analytics including traffic sources."""
-    if end_date is None:
-        end_date = datetime.today().strftime('%Y-%m-%d')
-
-    if start_date is None:
-        start_date = (datetime.today() - timedelta(days=365)).strftime('%Y-%m-%d')
-
-    # Define metrics in a consistent order
-    metrics_list = "views,comments,likes,dislikes,shares,averageViewDuration,averageViewPercentage,estimatedMinutesWatched"
-
-    analytics_response = youtube_analytics_client.reports().query(
-        ids="channel==MINE",
-        startDate=start_date,
-        endDate=end_date,
-        dimensions=dimensions,
-        metrics=metrics_list,
-        filters=f"video=={video_id}"
-    ).execute()
-
-    if not analytics_response.get("rows"):
-        bt.logging.warning("No analytics data found for video")
-        return []
-
-    # Define metric names in the same order as the metrics_list
-    metric_names = [
-        "views", "comments", "likes", "dislikes", "shares", 
-        "averageViewDuration", "averageViewPercentage", 
-        "estimatedMinutesWatched"
-    ]
-
-    if dimensions:
-        # Handle the case where dimensions are present
-        analytics_info = []
-        for row in analytics_response.get("rows", []):
-            dimension_values = row[:len(dimensions.split(','))]
-            metrics = dict(zip(metric_names, row[len(dimension_values):]))
-            for i, dimension in enumerate(dimensions.split(',')):
-                metrics[dimension] = dimension_values[i]
-            analytics_info.append(metrics)
-    else:
-        # Handle the case where no dimensions are present
-        analytics_data = analytics_response.get("rows", [])[0]
-        analytics_info = dict(zip(metric_names, analytics_data))
-
-    return analytics_info
-
-@retry(**YT_API_RETRY_CONFIG)
-def get_additional_video_analytics(youtube_analytics_client, video_id, start_date=None, end_date=None, ECO_MODE=False):
-    """Get additional video analytics including traffic sources and country data."""
-    if end_date is None:
-        end_date = datetime.today().strftime('%Y-%m-%d')
-
-    if start_date is None:
-        start_date = (datetime.today() - timedelta(days=365)).strftime('%Y-%m-%d')
-
-    # Get traffic source data for minutes watched
-    traffic_source_minutes = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "estimatedMinutesWatched", "insightTrafficSourceType")
-    
-    if ECO_MODE:
-        return {
-            "trafficSourceMinutes": traffic_source_minutes
-        }
-
-    # Get country data for minutes watched
-    country_minutes = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "estimatedMinutesWatched", "country")
-    
-    # Get minutes watched by creator content type
-    creator_content_type_minutes = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "estimatedMinutesWatched", "creatorContentType")
-    
-    # Get minutes watched by playback location type
-    playback_location_minutes = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "estimatedMinutesWatched", "insightPlaybackLocationType")
-    
-    # Get average view percentage by traffic source type
-    avg_view_percentage_by_traffic_source = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "averageViewPercentage", "insightTrafficSourceType")
-    
-    # Get minutes watched by live or on-demand
-    live_or_on_demand_minutes = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "estimatedMinutesWatched", "liveOrOnDemand")
-
-    # Fetch estimated minutes watched by YouTube product
-    youtube_product_minutes = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "estimatedMinutesWatched", "youtubeProduct")
-    
-    # # Get minutes watched by insight traffic source detail  // may need to filter insightTrafficSourceType==EXT_URL
-    # bt.logging.info("Fetching minutes watched by insight traffic source detail")
-    # traffic_source_detail_minutes = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "views", "insightTrafficSourceDetail")
-
-    # Fetch estimated minutes watched by device type
-    device_type_minutes = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "estimatedMinutesWatched", "deviceType")
-    
-    # Fetch estimated minutes watched by operating system
-    operating_system_minutes = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "estimatedMinutesWatched", "operatingSystem")
-    
-    # Fetch viewer percentage by age group and gender
-    age_group_viewer_percentage = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "viewerPercentage", "ageGroup,gender")
-    
-    # Fetch shares by sharing service
-    sharing_service_shares = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "shares", "sharingService")
-    
-    # Fetch audience watch ratio by elapsed video time ratio
-    elapsed_video_time_ratio_audience_watch_ratio = get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, "audienceWatchRatio", "elapsedVideoTimeRatio")
-
+    items = resp.get("items") or []
+    if not items:
+        raise Exception("No video found with matching ID")
+    info = items[0]
+    bcid = ("bitcast_" + hashlib.sha256(video_id.encode()).hexdigest()[:8]) if discrete_mode else video_id
     return {
-        "trafficSourceMinutes": traffic_source_minutes,
-        "countryMinutes": country_minutes,
-        "creatorContentTypeMinutes": creator_content_type_minutes,
-        "playbackLocationMinutes": playback_location_minutes,
-        "avgViewPercentageByTrafficSource": avg_view_percentage_by_traffic_source,
-        "liveOrOnDemandMinutes": live_or_on_demand_minutes,
-        "youtubeProductMinutes": youtube_product_minutes,
-        "sharingServiceShares": sharing_service_shares,
-        "deviceTypeMinutes": device_type_minutes,
-        "operatingSystemMinutes": operating_system_minutes,
-        "ageGroupViewerPercentage": age_group_viewer_percentage,
-        "elapsedVideoTimeRatioAudienceWatchRatio": elapsed_video_time_ratio_audience_watch_ratio
+        "videoId": video_id,
+        "bitcastVideoId": bcid,
+        "title": info["snippet"]["title"],
+        "description": info["snippet"]["description"],
+        "publishedAt": info["snippet"]["publishedAt"],
+        "viewCount": info["statistics"].get("viewCount", 0),
+        "likeCount": info["statistics"].get("likeCount", 0),
+        "commentCount": info["statistics"].get("commentCount", 0),
+        "duration": info["contentDetails"]["duration"],
+        "caption": info["contentDetails"]["caption"].lower() == "true",
+        "privacyStatus": info["status"]["privacyStatus"]
     }
 
-@retry(**YT_API_RETRY_CONFIG)
-def get_video_analytics_by_dimension(youtube_analytics_client, video_id, start_date, end_date, metric, dimensions):
-    """Get video analytics grouped by specified dimensions.
+def get_video_analytics(youtube_analytics_client, video_id, start_date=None, end_date=None, metric_dims=None):
+    """Get video analytics based on specified metric-dimension combinations.
     
     Args:
         youtube_analytics_client: The YouTube Analytics API client
-        video_id: The ID of the video to get analytics for
-        start_date: Start date for analytics in YYYY-MM-DD format
-        end_date: End date for analytics in YYYY-MM-DD format
-        metric: The metric to retrieve (e.g., "views", "estimatedMinutesWatched")
-        dimensions: Comma-separated list of dimensions to group by
+        video_id: The YouTube video ID
+        start_date: Start date for analytics (defaults to 1 year ago)
+        end_date: End date for analytics (defaults to today)
+        metric_dims: Dictionary of {output_key: (metric, dimensions)} to fetch
+                    If None, raises ValueError
+    
+    Returns:
+        Dictionary of analytics results keyed by the provided output_keys
     """
-    try:
-        response = youtube_analytics_client.reports().query(
-            ids="channel==MINE",
-            startDate=start_date,
-            endDate=end_date,
-            dimensions=dimensions,
-            metrics=metric,
-            filters=f"video=={video_id}"
-        ).execute()
-
-        if not response.get("rows"):
-            return {}
-
-        analytics_data = {}
-        for row in response.get("rows", []):
-            dimension_values = row[:-1]  # All but last element are dimension values
-            metric_value = row[-1]  # Last element is the metric value
+    if metric_dims is None:
+        raise ValueError("metric_dims parameter is required")
+        
+    end = end_date or datetime.today().strftime('%Y-%m-%d')
+    start = start_date or (datetime.today() - timedelta(days=365)).strftime('%Y-%m-%d')
+    
+    # Group metrics by dimensions to consolidate API calls
+    dimension_groups = {}
+    key_to_metric_dim = {}
+    
+    for key, (metric, dims) in metric_dims.items():
+        key_to_metric_dim[key] = (metric, dims)
+        dims_key = dims or ""  # Use empty string for no dimensions
+        
+        if dims_key not in dimension_groups:
+            dimension_groups[dims_key] = []
+        dimension_groups[dims_key].append((key, metric))
+    
+    results = {}
+    day_structured_data = {}
+    day_metrics = {}
+    has_day_dimension = False
+    
+    # Make consolidated API calls for each dimension group
+    for dims_key, metrics_list in dimension_groups.items():
+        if not metrics_list:
+            continue
             
-            # Convert tuple keys to string keys for JSON compatibility
-            if len(dimension_values) > 1:
-                key = "|".join(str(v) for v in dimension_values)
-            else:
-                key = str(dimension_values[0])
+        # Extract just the metric names for the API call
+        metric_names = [metric for _, metric in metrics_list]
+        key_names = [key for key, _ in metrics_list]
+        
+        try:
+            # Make consolidated API call
+            consolidated_results = _query_multiple_metrics(
+                youtube_analytics_client, start, end,
+                metric_names, dims_key if dims_key else None,
+                filters=f"video=={video_id}"
+            )
+            
+            # Distribute results back to individual keys
+            for i, (key, metric) in enumerate(metrics_list):
+                dims = key_to_metric_dim[key][1]
+                query_result = consolidated_results.get(metric, {} if dims else [])
                 
-            analytics_data[key] = metric_value
-
-        return analytics_data
-    except Exception as e:
-        bt.logging.warning(f"Error getting analytics: {_format_error(e)}")
-        return {}
-
-@retry(**YT_API_RETRY_CONFIG)
-def get_video_traffic_source_views_analytics(youtube_analytics_client, video_id, start_date, end_date, dimensions="insightTrafficSourceType"):
-    """Get traffic source analytics for views for a specific video."""
-    return get_video_analytics_by_dimension(
-        youtube_analytics_client, 
-        video_id, 
-        start_date, 
-        end_date, 
-        "views", 
-        dimensions
-    )
-
-@retry(**YT_API_RETRY_CONFIG)
-def get_video_traffic_source_minutes_analytics(youtube_analytics_client, video_id, start_date, end_date, dimensions="insightTrafficSourceType"):
-    """Get traffic source analytics for minutes watched for a specific video."""
-    return get_video_analytics_by_dimension(
-        youtube_analytics_client, 
-        video_id, 
-        start_date, 
-        end_date, 
-        "estimatedMinutesWatched", 
-        dimensions
-    )
-
-@retry(**YT_API_RETRY_CONFIG)
-def get_video_country_views_analytics(youtube_analytics_client, video_id, start_date, end_date, dimensions="country"):
-    """Get views analytics by country for a specific video."""
-    return get_video_analytics_by_dimension(
-        youtube_analytics_client, 
-        video_id, 
-        start_date, 
-        end_date, 
-        "views", 
-        dimensions
-    )
-
-@retry(**YT_API_RETRY_CONFIG)
-def get_video_country_minutes_analytics(youtube_analytics_client, video_id, start_date, end_date, dimensions="country"):
-    """Get minutes watched analytics by country for a specific video."""
-    return get_video_analytics_by_dimension(
-        youtube_analytics_client, 
-        video_id, 
-        start_date, 
-        end_date, 
-        "estimatedMinutesWatched", 
-        dimensions
-    )
+                # Handle scalar values for metrics with no dimensions
+                if not dims and isinstance(query_result, (int, float)):
+                    results[key] = query_result
+                elif not dims and isinstance(query_result, list) and query_result:
+                    results[key] = query_result[0] if query_result else 0
+                # Handle simple day dimension (just "day")
+                elif dims == "day":
+                    has_day_dimension = True
+                    day_metrics[key] = query_result
+                    results[key] = query_result
+                # Handle multi-dimensional data that includes day
+                elif dims and "day" in dims and "," in dims:
+                    has_day_dimension = True
+                    
+                    # Skip empty results
+                    if not query_result or not isinstance(query_result, dict):
+                        results[key] = {}
+                        continue
+                        
+                    # Create a nested structure where data is organized by day first
+                    day_data = {}
+                    for combined_key, value in query_result.items():
+                        # Split the combined key (e.g., "DESKTOP|2025-05-12")
+                        parts = combined_key.split('|')
+                        if len(parts) == 2:
+                            dimension_value = parts[0]
+                            day = parts[1]
+                            
+                            # Initialize nested dictionaries
+                            if day not in day_data:
+                                day_data[day] = {}
+                            
+                            # Add data
+                            day_data[day][dimension_value] = value
+                    
+                    # Store the day-structured data for later merge
+                    day_structured_data[key] = day_data
+                    
+                    # Also store the original data
+                    results[key] = query_result
+                else:
+                    # Standard result
+                    results[key] = query_result
+                    
+        except Exception as e:
+            bt.logging.warning(f"Failed to retrieve analytics for dimension '{dims_key}': {_format_error(e)}")
+            # Set individual results to None for this dimension group
+            for key, _ in metrics_list:
+                results[key] = None
+    
+    # Consolidate day-structured data if there are any day dimensions
+    if has_day_dimension:
+        # Create a day_metrics entry for uniform access
+        results["day_metrics"] = {}
+        
+        # Collect all days from both simple and complex day metrics
+        all_days = set()
+        
+        # Add days from day_metrics (simple "day" dimension)
+        for metric_data in day_metrics.values():
+            if isinstance(metric_data, dict):
+                all_days.update(metric_data.keys())
+        
+        # Add days from day_structured_data (complex dimensions with "day")
+        for day_dict in day_structured_data.values():
+            all_days.update(day_dict.keys())
+        
+        # Create entries for each day
+        for day in sorted(all_days):
+            day_entry = {"day": day}
+            
+            # Add simple metrics with day dimension
+            for key, data in day_metrics.items():
+                if isinstance(data, dict):
+                    day_entry[key] = data.get(day, 0)
+            
+            # Add complex metrics
+            for key, day_data in day_structured_data.items():
+                if day in day_data:
+                    day_entry[key] = day_data[day]
+            
+            results["day_metrics"][day] = day_entry
+    
+    return results
 
 # ============================================================================
 # Transcript Functions
@@ -611,22 +473,11 @@ def get_video_transcript(video_id, rapid_api_key):
 
 def _format_error(e):
     """Format error message to include only error type and brief summary."""
-    error_type = type(e).__name__
-    
-    # For HTTP errors, try to extract status code and error message
+    et = type(e).__name__
     if hasattr(e, 'response') and hasattr(e.response, 'status_code'):
-        return f"{error_type} ({e.response.status_code})"
-    
-    # For API errors, try to extract error code and message
+        return f"{et} ({e.response.status_code})"
     if hasattr(e, 'error') and isinstance(e.error, dict):
-        error_details = e.error.get('details', [{}])[0]
-        error_message = error_details.get('message', 'unknown error')
-        return f"{error_type} ({error_message})"
-    
-    # For other errors, return type and first line of message, excluding URLs
-    error_msg = str(e)
-    # Remove URLs from error message
-    error_msg = re.sub(r'https?://\S+', '', error_msg)
-    # Get first line and clean up
-    error_msg = error_msg.split('\n')[0].strip()
-    return f"{error_type} ({error_msg})"
+        details = e.error.get('details', [{}])[0].get('message', 'unknown error')
+        return f"{et} ({details})"
+    msg = re.sub(r'https?://\S+', '', str(e)).split('\n')[0].strip()
+    return f"{et} ({msg})"

--- a/bitcast/validator/utils/config.py
+++ b/bitcast/validator/utils/config.py
@@ -15,7 +15,7 @@ CACHE_DIRS = {
     "blacklist": os.path.join(CACHE_ROOT, "blacklist")
 }
 
-__version__ = "1.4.0"
+__version__ = "1.4.2"
 
 # required
 BITCAST_SERVER_URL = os.getenv('BITCAST_SERVER_URL', 'http://44.227.253.127')

--- a/dev/bt_logging_patch.py
+++ b/dev/bt_logging_patch.py
@@ -1,0 +1,99 @@
+"""
+Patch for replacing bittensor logging with standard Python logging.
+
+IMPORTANT: This module must be imported before any other modules that use bittensor.
+Example usage:
+  
+  # At the very top of your entry point script:
+  import bt_logging_patch
+  
+  # Then continue with your normal imports
+  import other_modules
+"""
+
+import sys
+import types
+import logging
+import importlib.util
+
+# Configure logging to show all logs
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+)
+
+print("🔧 Patching bittensor.logging with standard logging")
+
+# Create a mock logging class that forwards to standard logging
+class MockLogging:
+    def __init__(self):
+        self.logger = logging.getLogger("bittensor")
+        self.logger.setLevel(logging.DEBUG)
+    
+    def debug(self, msg, *args, **kwargs):
+        self.logger.debug(msg, *args, **kwargs)
+    
+    def info(self, msg, *args, **kwargs):
+        self.logger.info(msg, *args, **kwargs)
+    
+    def warning(self, msg, *args, **kwargs):
+        self.logger.warning(msg, *args, **kwargs)
+    
+    def error(self, msg, *args, **kwargs):
+        self.logger.error(msg, *args, **kwargs)
+    
+    def critical(self, msg, *args, **kwargs):
+        self.logger.critical(msg, *args, **kwargs)
+    
+    def success(self, msg, *args, **kwargs):
+        # Map success to info with a prefix
+        self.logger.info(f"SUCCESS: {msg}", *args, **kwargs)
+    
+    def trace(self, msg, *args, **kwargs):
+        # Map trace to debug with a prefix
+        self.logger.debug(f"TRACE: {msg}", *args, **kwargs)
+    
+    # Mock configuration methods to do nothing
+    def set_config(self, *args, **kwargs):
+        pass
+    
+    def add_args(self, *args, **kwargs):
+        pass
+
+# Try to import the real bittensor module
+try:
+    # Check if bittensor is already in sys.modules
+    if "bittensor" in sys.modules:
+        # Get the existing module
+        bittensor = sys.modules["bittensor"]
+        # Replace only its logging attribute
+        bittensor.logging = MockLogging()
+        print("✅ Replaced logging in existing bittensor module")
+    else:
+        # Try to import the real module
+        import bittensor
+        # Save the original module
+        real_bittensor = bittensor
+        # Replace only its logging attribute
+        real_bittensor.logging = MockLogging()
+        # Update sys.modules to use our modified module
+        sys.modules["bittensor"] = real_bittensor
+        print("✅ Imported real bittensor module and replaced its logging")
+    
+    # Also patch bt for imports like "import bt"
+    if "bt" not in sys.modules:
+        sys.modules["bt"] = sys.modules["bittensor"]
+        print("✅ Added 'bt' as an alias to the patched bittensor module")
+    
+except ImportError:
+    print("⚠️ Could not import bittensor - creating minimal mock")
+    # Create a minimal mock module with just logging
+    mock_bittensor = types.ModuleType("bittensor")
+    mock_bittensor.logging = MockLogging()
+    
+    # Add the mock module to sys.modules
+    sys.modules["bittensor"] = mock_bittensor
+    sys.modules["bt"] = mock_bittensor
+    print("✅ Created minimal mock for bittensor (logging only)")
+
+print("✅ Patching complete - bt.logging and bittensor.logging now use standard logging") 

--- a/dev/internal_api.py
+++ b/dev/internal_api.py
@@ -1,9 +1,20 @@
+# Import bt_logging_patch before anything else
+import bt_logging_patch
+
+import sys
+import logging
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import List, Dict, Any
 from bitcast.validator.socials.youtube.youtube_evaluation import vet_video
 from bitcast.validator.socials.youtube import youtube_utils
 from bitcast.validator.utils.config import RAPID_API_KEY
+
+# Configure logging to show all logs
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
 
 # Note: This API is intended solely for the use of the subnet development team.
 # It can be ignored by anyone else.
@@ -23,6 +34,13 @@ class VideoRequest(BaseModel):
 @app.post("/vet_video/")
 async def vet_video_endpoint(request: VideoRequest):
     try:
+        # Verify bt.logging mock is working
+        logging.debug("=== Starting vet_video_endpoint ===")
+        
+        # Add debug logs
+        logging.debug(f"Received request for video: {request.video_id}")
+        logging.debug(f"Request contains {len(request.briefs)} briefs")
+        
         # Call the vet_video function from youtube_scoring.py
         result = vet_video(
             video_id=request.video_id,
@@ -30,8 +48,15 @@ async def vet_video_endpoint(request: VideoRequest):
             video_data=request.video_data,
             video_analytics=request.video_analytics
         )
+        
+        # Log the result
+        logging.debug(f"Result: met {len(result['met_brief_ids'])} briefs out of {len(request.briefs)}")
+
+        # Return both the decision details and brief reasonings
         return result
+    
     except Exception as e:
+        logging.error(f"Error in vet_video_endpoint: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
 def main():

--- a/dev/internal_api_wrapper.py
+++ b/dev/internal_api_wrapper.py
@@ -1,0 +1,3 @@
+import bt_logging_patch
+import internal_api
+internal_api.main()

--- a/dev/run_internal_api.sh
+++ b/dev/run_internal_api.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 
-# Stop the application if it's already running
-pm2 delete internal_api
+# Set PYTHONPATH to ensure modules can be found
+export PYTHONPATH=$PYTHONPATH:$(pwd)
 
-# Run the application using pm2 with the process name "miner_dashboard"
-pm2 start "$(dirname "${BASH_SOURCE[0]}")/internal_api.py" --name internal_api --interpreter python
+# Stop the application if it's already running
+pm2 delete internal_api 2>/dev/null || true
+
+# Create a wrapper script that imports the required modules
+cd $(dirname "$0")
+cat > internal_api_wrapper.py << EOF
+import bt_logging_patch
+import internal_api
+internal_api.main()
+EOF
+
+# Run the API with pm2
+pm2 start --name internal_api --interpreter python3 internal_api_wrapper.py
+
+# Note: We're keeping the wrapper script for pm2 to use it

--- a/tests/end_to_end/get_rewards/test_complex_scenario.py
+++ b/tests/end_to_end/get_rewards/test_complex_scenario.py
@@ -44,7 +44,9 @@ with patch.dict('os.environ', {'DISABLE_LLM_CACHING': 'true'}):
         YT_MIN_SUBS,
         YT_MIN_CHANNEL_AGE,
         YT_MIN_CHANNEL_RETENTION,
-        YT_MIN_MINS_WATCHED
+        YT_MIN_MINS_WATCHED,
+        YT_REWARD_DELAY,
+        YT_ROLLING_WINDOW
     )
 
 # Set up logging
@@ -452,82 +454,95 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
     
     mock_get_video_data.side_effect = mock_get_video_data_side_effect
     
-    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, dimensions=None):
-        logger.info(f"get_video_analytics called with video_id: {video_id}, dimensions: {dimensions}")
-        if dimensions == 'day':
-            # For day-based analytics, split the total watch time across days
-            video_day_metrics = {
-                # UID 1's videos (50% more watch time)
-                "test_video_1_uid1": 900,  # 600 * 1.5
-                "test_video_2_uid1": 375,  # 250 * 1.5
-                "test_video_3_uid1": 150,  # 100 * 1.5
-                "test_video_4_uid1": 450,  # 300 * 1.5
-                # UID 2's videos (original watch time)
-                "test_video_1_uid2": 600,
-                "test_video_2_uid2": 250,
-                "test_video_3_uid2": 100,
-                "test_video_4_uid2": 300
+    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, dimensions=None, metric_dims=None):
+        logger.info(f"get_video_analytics called with video_id: {video_id}, dimensions: {dimensions}, metric_dims: {metric_dims}")
+        
+        # Use dates relative to today to work with YT_REWARD_DELAY and YT_ROLLING_WINDOW from config
+        today = datetime.now()
+        day1 = (today - timedelta(days=YT_REWARD_DELAY + 1)).strftime('%Y-%m-%d')
+        day2 = (today - timedelta(days=YT_REWARD_DELAY + 2)).strftime('%Y-%m-%d')
+        
+        # Determine video watch time based on video ID
+        video_day_metrics = {
+            # UID 1's videos (50% more watch time)
+            "test_video_1_uid1": 900,  # 600 * 1.5
+            "test_video_2_uid1": 375,  # 250 * 1.5
+            "test_video_3_uid1": 150,  # 100 * 1.5
+            "test_video_4_uid1": 450,  # 300 * 1.5
+            # UID 2's videos (original watch time)
+            "test_video_1_uid2": 600,
+            "test_video_2_uid2": 250,
+            "test_video_3_uid2": 100,
+            "test_video_4_uid2": 300
+        }
+        total_minutes = video_day_metrics.get(video_id, 0)
+        half_minutes = total_minutes / 2
+        
+        # Create day_metrics structure (all traffic is organic)
+        day_metrics = {
+            day1: {
+                "day": day1,
+                "estimatedMinutesWatched": half_minutes,
+            },
+            day2: {
+                "day": day2,
+                "estimatedMinutesWatched": half_minutes,
             }
-            total_minutes = video_day_metrics[video_id]
-            logger.info(f"Returning day metrics for {video_id}: {total_minutes} minutes")
-            half_minutes = total_minutes / 2
+        }
+        
+        # Define traffic source minutes (50% YT_CHANNEL, 50% EXT_URL)
+        traffic_source_minutes = {
+            "YT_CHANNEL": total_minutes / 2,
+            "EXT_URL": total_minutes / 2
+        }
+        
+        # Handle metric_dims parameter (modern approach)
+        if metric_dims:
+            # Create result with top-level metrics for vetting
+            result = {
+                "averageViewPercentage": 50,
+                "estimatedMinutesWatched": total_minutes,
+                "trafficSourceMinutes": traffic_source_minutes,
+                "day_metrics": day_metrics
+            }
+            
+            # Add metrics for each requested metric
+            for key, (metric, dims) in metric_dims.items():
+                if dims == "day":
+                    if metric == "estimatedMinutesWatched":
+                        result[key] = {
+                            day1: half_minutes,
+                            day2: half_minutes
+                        }
+                    else:
+                        result[key] = {
+                            day1: half_minutes / 2,
+                            day2: half_minutes / 2
+                        }
+            
+            logger.info(f"Returning day metrics structure for {video_id}: {result}")
+            return result
+            
+        # Legacy format support for backward compatibility (dimensions parameter)
+        elif dimensions == 'day':
+            # For day-based analytics, return day-level data
             return [
                 {
-                    "day": "2023-01-15",
+                    "day": day1,
                     "estimatedMinutesWatched": half_minutes
                 },
                 {
-                    "day": "2023-01-16",
+                    "day": day2,
                     "estimatedMinutesWatched": half_minutes
                 }
             ]
         else:
-            # For overall metrics, return the total watch time
-            video_metrics = {
-                # UID 1's videos (50% more watch time)
-                "test_video_1_uid1": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 900,  # 600 * 1.5
-                    "trafficSourceMinutes": {"YT_CHANNEL": 400, "EXT_URL": 500}
-                },
-                "test_video_2_uid1": {
-                    "averageViewPercentage": 55,
-                    "estimatedMinutesWatched": 375,  # 250 * 1.5
-                    "trafficSourceMinutes": {"YT_CHANNEL": 175, "EXT_URL": 200}
-                },
-                "test_video_3_uid1": {
-                    "averageViewPercentage": 45,
-                    "estimatedMinutesWatched": 150,  # 100 * 1.5
-                    "trafficSourceMinutes": {"YT_CHANNEL": 50, "EXT_URL": 100}
-                },
-                "test_video_4_uid1": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 450,  # 300 * 1.5
-                    "trafficSourceMinutes": {"YT_CHANNEL": 250, "EXT_URL": 200}
-                },
-                # UID 2's videos (original watch time)
-                "test_video_1_uid2": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 600,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 300, "EXT_URL": 300}
-                },
-                "test_video_2_uid2": {
-                    "averageViewPercentage": 55,
-                    "estimatedMinutesWatched": 250,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 100, "EXT_URL": 150}
-                },
-                "test_video_3_uid2": {
-                    "averageViewPercentage": 45,
-                    "estimatedMinutesWatched": 100,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 40, "EXT_URL": 60}
-                },
-                "test_video_4_uid2": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 300,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 150, "EXT_URL": 150}
-                }
+            # For non-daily metrics, return the regular metrics
+            result = {
+                "averageViewPercentage": 50,
+                "estimatedMinutesWatched": total_minutes,
+                "trafficSourceMinutes": traffic_source_minutes
             }
-            result = video_metrics[video_id]
             logger.info(f"Returning overall metrics for {video_id}: {result}")
             return result
     

--- a/tests/end_to_end/get_rewards/test_complex_scenario_with_weights.py
+++ b/tests/end_to_end/get_rewards/test_complex_scenario_with_weights.py
@@ -44,7 +44,9 @@ with patch.dict('os.environ', {'DISABLE_LLM_CACHING': 'true'}):
         YT_MIN_SUBS,
         YT_MIN_CHANNEL_AGE,
         YT_MIN_CHANNEL_RETENTION,
-        YT_MIN_MINS_WATCHED
+        YT_MIN_MINS_WATCHED,
+        YT_REWARD_DELAY,
+        YT_ROLLING_WINDOW
     )
 
 # Set up logging
@@ -452,82 +454,95 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
     
     mock_get_video_data.side_effect = mock_get_video_data_side_effect
     
-    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, dimensions=None):
-        logger.info(f"get_video_analytics called with video_id: {video_id}, dimensions: {dimensions}")
-        if dimensions == 'day':
-            # For day-based analytics, split the total watch time across days
-            video_day_metrics = {
-                # UID 1's videos (different ratios for different briefs)
-                "test_video_1_uid1": 1200,  # 2x better for Brief 1
-                "test_video_2_uid1": 300,   # 1.2x better for both briefs
-                "test_video_3_uid1": 150,   # 1.5x better but matches neither brief
-                "test_video_4_uid1": 400,   # 1.33x better for Brief 2
-                # UID 2's videos (original watch time)
-                "test_video_1_uid2": 600,
-                "test_video_2_uid2": 250,
-                "test_video_3_uid2": 100,
-                "test_video_4_uid2": 300
+    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, dimensions=None, metric_dims=None):
+        logger.info(f"get_video_analytics called with video_id: {video_id}, dimensions: {dimensions}, metric_dims: {metric_dims}")
+        
+        # Use dates relative to today to work with YT_REWARD_DELAY and YT_ROLLING_WINDOW from config
+        today = datetime.now()
+        day1 = (today - timedelta(days=YT_REWARD_DELAY + 1)).strftime('%Y-%m-%d')
+        day2 = (today - timedelta(days=YT_REWARD_DELAY + 2)).strftime('%Y-%m-%d')
+        
+        # Determine video watch time based on video ID
+        video_day_metrics = {
+            # UID 1's videos (different ratios for different briefs)
+            "test_video_1_uid1": 1200,  # 2x better for Brief 1
+            "test_video_2_uid1": 300,   # 1.2x better for both briefs
+            "test_video_3_uid1": 150,   # 1.5x better but matches neither brief
+            "test_video_4_uid1": 400,   # 1.33x better for Brief 2
+            # UID 2's videos (original watch time)
+            "test_video_1_uid2": 600,
+            "test_video_2_uid2": 250,
+            "test_video_3_uid2": 100,
+            "test_video_4_uid2": 300
+        }
+        total_minutes = video_day_metrics.get(video_id, 0)
+        half_minutes = total_minutes / 2
+        
+        # Create day_metrics structure (all traffic is organic)
+        day_metrics = {
+            day1: {
+                "day": day1,
+                "estimatedMinutesWatched": half_minutes,
+            },
+            day2: {
+                "day": day2,
+                "estimatedMinutesWatched": half_minutes,
             }
-            total_minutes = video_day_metrics[video_id]
-            logger.info(f"Returning day metrics for {video_id}: {total_minutes} minutes")
-            half_minutes = total_minutes / 2
+        }
+        
+        # Define traffic source minutes (50% YT_CHANNEL, 50% EXT_URL)
+        traffic_source_minutes = {
+            "YT_CHANNEL": total_minutes / 2,
+            "EXT_URL": total_minutes / 2
+        }
+        
+        # Handle metric_dims parameter (modern approach)
+        if metric_dims:
+            # Create result with top-level metrics for vetting
+            result = {
+                "averageViewPercentage": 50,
+                "estimatedMinutesWatched": total_minutes,
+                "trafficSourceMinutes": traffic_source_minutes,
+                "day_metrics": day_metrics
+            }
+            
+            # Add metrics for each requested metric
+            for key, (metric, dims) in metric_dims.items():
+                if dims == "day":
+                    if metric == "estimatedMinutesWatched":
+                        result[key] = {
+                            day1: half_minutes,
+                            day2: half_minutes
+                        }
+                    else:
+                        result[key] = {
+                            day1: half_minutes / 2,
+                            day2: half_minutes / 2
+                        }
+            
+            logger.info(f"Returning day metrics structure for {video_id}: {result}")
+            return result
+            
+        # Legacy format support for backward compatibility (dimensions parameter)
+        elif dimensions == 'day':
+            # For day-based analytics, return day-level data
             return [
                 {
-                    "day": "2023-01-15",
+                    "day": day1,
                     "estimatedMinutesWatched": half_minutes
                 },
                 {
-                    "day": "2023-01-16",
+                    "day": day2,
                     "estimatedMinutesWatched": half_minutes
                 }
             ]
         else:
-            # For overall metrics, return the total watch time
-            video_metrics = {
-                # UID 1's videos (different ratios for different briefs)
-                "test_video_1_uid1": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 1200,  # 2x better for Brief 1
-                    "trafficSourceMinutes": {"YT_CHANNEL": 600, "EXT_URL": 600}
-                },
-                "test_video_2_uid1": {
-                    "averageViewPercentage": 55,
-                    "estimatedMinutesWatched": 300,   # 1.2x better for both briefs
-                    "trafficSourceMinutes": {"YT_CHANNEL": 150, "EXT_URL": 150}
-                },
-                "test_video_3_uid1": {
-                    "averageViewPercentage": 45,
-                    "estimatedMinutesWatched": 150,   # 1.5x better but matches neither brief
-                    "trafficSourceMinutes": {"YT_CHANNEL": 75, "EXT_URL": 75}
-                },
-                "test_video_4_uid1": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 400,   # 1.33x better for Brief 2
-                    "trafficSourceMinutes": {"YT_CHANNEL": 200, "EXT_URL": 200}
-                },
-                # UID 2's videos (original watch time)
-                "test_video_1_uid2": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 600,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 300, "EXT_URL": 300}
-                },
-                "test_video_2_uid2": {
-                    "averageViewPercentage": 55,
-                    "estimatedMinutesWatched": 250,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 125, "EXT_URL": 125}
-                },
-                "test_video_3_uid2": {
-                    "averageViewPercentage": 45,
-                    "estimatedMinutesWatched": 100,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 50, "EXT_URL": 50}
-                },
-                "test_video_4_uid2": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 300,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 150, "EXT_URL": 150}
-                }
+            # For non-daily metrics, return the regular metrics
+            result = {
+                "averageViewPercentage": 50,
+                "estimatedMinutesWatched": total_minutes,
+                "trafficSourceMinutes": traffic_source_minutes
             }
-            result = video_metrics[video_id]
             logger.info(f"Returning overall metrics for {video_id}: {result}")
             return result
     

--- a/tests/end_to_end/get_rewards/test_complex_scenario_with_weights_and_burn.py
+++ b/tests/end_to_end/get_rewards/test_complex_scenario_with_weights_and_burn.py
@@ -44,7 +44,9 @@ with patch.dict('os.environ', {'DISABLE_LLM_CACHING': 'true'}):
         YT_MIN_SUBS,
         YT_MIN_CHANNEL_AGE,
         YT_MIN_CHANNEL_RETENTION,
-        YT_MIN_MINS_WATCHED
+        YT_MIN_MINS_WATCHED,
+        YT_REWARD_DELAY,
+        YT_ROLLING_WINDOW
     )
 
 # Set up logging
@@ -452,82 +454,95 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
     
     mock_get_video_data.side_effect = mock_get_video_data_side_effect
     
-    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, dimensions=None):
-        logger.info(f"get_video_analytics called with video_id: {video_id}, dimensions: {dimensions}")
-        if dimensions == 'day':
-            # For day-based analytics, split the total watch time across days
-            video_day_metrics = {
-                # UID 1's videos (different ratios for different briefs)
-                "test_video_1_uid1": 1200,  # 2x better for Brief 1
-                "test_video_2_uid1": 300,   # 1.2x better for both briefs
-                "test_video_3_uid1": 150,   # 1.5x better but matches neither brief
-                "test_video_4_uid1": 400,   # 1.33x better for Brief 2
-                # UID 2's videos (original watch time)
-                "test_video_1_uid2": 600,
-                "test_video_2_uid2": 250,
-                "test_video_3_uid2": 100,
-                "test_video_4_uid2": 300
+    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, dimensions=None, metric_dims=None):
+        logger.info(f"get_video_analytics called with video_id: {video_id}, dimensions: {dimensions}, metric_dims: {metric_dims}")
+        
+        # Use dates relative to today to work with YT_REWARD_DELAY and YT_ROLLING_WINDOW from config
+        today = datetime.now()
+        day1 = (today - timedelta(days=YT_REWARD_DELAY + 1)).strftime('%Y-%m-%d')
+        day2 = (today - timedelta(days=YT_REWARD_DELAY + 2)).strftime('%Y-%m-%d')
+        
+        # Determine video watch time based on video ID
+        video_day_metrics = {
+            # UID 1's videos (different ratios for different briefs)
+            "test_video_1_uid1": 1200,  # 2x better for Brief 1
+            "test_video_2_uid1": 300,   # 1.2x better for both briefs
+            "test_video_3_uid1": 150,   # 1.5x better but matches neither brief
+            "test_video_4_uid1": 400,   # 1.33x better for Brief 2
+            # UID 2's videos (original watch time)
+            "test_video_1_uid2": 600,
+            "test_video_2_uid2": 250,
+            "test_video_3_uid2": 100,
+            "test_video_4_uid2": 300
+        }
+        total_minutes = video_day_metrics.get(video_id, 0)
+        half_minutes = total_minutes / 2
+        
+        # Create day_metrics structure (all traffic is organic)
+        day_metrics = {
+            day1: {
+                "day": day1,
+                "estimatedMinutesWatched": half_minutes,
+            },
+            day2: {
+                "day": day2,
+                "estimatedMinutesWatched": half_minutes,
             }
-            total_minutes = video_day_metrics[video_id]
-            logger.info(f"Returning day metrics for {video_id}: {total_minutes} minutes")
-            half_minutes = total_minutes / 2
+        }
+        
+        # Define traffic source minutes (50% YT_CHANNEL, 50% EXT_URL)
+        traffic_source_minutes = {
+            "YT_CHANNEL": total_minutes / 2,
+            "EXT_URL": total_minutes / 2
+        }
+        
+        # Handle metric_dims parameter (modern approach)
+        if metric_dims:
+            # Create result with top-level metrics for vetting
+            result = {
+                "averageViewPercentage": 50,
+                "estimatedMinutesWatched": total_minutes,
+                "trafficSourceMinutes": traffic_source_minutes,
+                "day_metrics": day_metrics
+            }
+            
+            # Add metrics for each requested metric
+            for key, (metric, dims) in metric_dims.items():
+                if dims == "day":
+                    if metric == "estimatedMinutesWatched":
+                        result[key] = {
+                            day1: half_minutes,
+                            day2: half_minutes
+                        }
+                    else:
+                        result[key] = {
+                            day1: half_minutes / 2,
+                            day2: half_minutes / 2
+                        }
+            
+            logger.info(f"Returning day metrics structure for {video_id}: {result}")
+            return result
+            
+        # Legacy format support for backward compatibility (dimensions parameter)
+        elif dimensions == 'day':
+            # For day-based analytics, return day-level data
             return [
                 {
-                    "day": "2023-01-15",
+                    "day": day1,
                     "estimatedMinutesWatched": half_minutes
                 },
                 {
-                    "day": "2023-01-16",
+                    "day": day2,
                     "estimatedMinutesWatched": half_minutes
                 }
             ]
         else:
-            # For overall metrics, return the total watch time
-            video_metrics = {
-                # UID 1's videos (different ratios for different briefs)
-                "test_video_1_uid1": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 1200,  # 2x better for Brief 1
-                    "trafficSourceMinutes": {"YT_CHANNEL": 600, "EXT_URL": 600}
-                },
-                "test_video_2_uid1": {
-                    "averageViewPercentage": 55,
-                    "estimatedMinutesWatched": 300,   # 1.2x better for both briefs
-                    "trafficSourceMinutes": {"YT_CHANNEL": 150, "EXT_URL": 150}
-                },
-                "test_video_3_uid1": {
-                    "averageViewPercentage": 45,
-                    "estimatedMinutesWatched": 150,   # 1.5x better but matches neither brief
-                    "trafficSourceMinutes": {"YT_CHANNEL": 75, "EXT_URL": 75}
-                },
-                "test_video_4_uid1": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 400,   # 1.33x better for Brief 2
-                    "trafficSourceMinutes": {"YT_CHANNEL": 200, "EXT_URL": 200}
-                },
-                # UID 2's videos (original watch time)
-                "test_video_1_uid2": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 600,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 300, "EXT_URL": 300}
-                },
-                "test_video_2_uid2": {
-                    "averageViewPercentage": 55,
-                    "estimatedMinutesWatched": 250,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 125, "EXT_URL": 125}
-                },
-                "test_video_3_uid2": {
-                    "averageViewPercentage": 45,
-                    "estimatedMinutesWatched": 100,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 50, "EXT_URL": 50}
-                },
-                "test_video_4_uid2": {
-                    "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 300,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 150, "EXT_URL": 150}
-                }
+            # For non-daily metrics, return the regular metrics
+            result = {
+                "averageViewPercentage": 50,
+                "estimatedMinutesWatched": total_minutes,
+                "trafficSourceMinutes": traffic_source_minutes
             }
-            result = video_metrics[video_id]
             logger.info(f"Returning overall metrics for {video_id}: {result}")
             return result
     

--- a/tests/end_to_end/reward/test_reward_complex.py
+++ b/tests/end_to_end/reward/test_reward_complex.py
@@ -43,7 +43,9 @@ with patch.dict('os.environ', {'DISABLE_LLM_CACHING': 'true'}):
         YT_MIN_SUBS,
         YT_MIN_CHANNEL_AGE,
         YT_MIN_CHANNEL_RETENTION,
-        YT_MIN_MINS_WATCHED
+        YT_MIN_MINS_WATCHED,
+        YT_REWARD_DELAY,
+        YT_ROLLING_WINDOW
     )
 
 # Set up logging
@@ -336,7 +338,110 @@ def test_reward_function(mock_make_openai_request, mock_get_transcript,
     
     mock_get_video_data.side_effect = mock_get_video_data_side_effect
     
-    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, dimensions=None):
+    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, dimensions=None, metric_dims=None):
+        # Use dates relative to today to work with YT_REWARD_DELAY and YT_ROLLING_WINDOW from config
+        today = datetime.now()
+        day1 = (today - timedelta(days=YT_REWARD_DELAY + 1)).strftime('%Y-%m-%d')
+        day2 = (today - timedelta(days=YT_REWARD_DELAY + 2)).strftime('%Y-%m-%d')
+        
+        # Handle the new metric_dims parameter
+        if metric_dims:
+            # Check if this is a daily metrics request
+            has_day_dimension = any('day' in dims for _, dims in metric_dims.values() if dims)
+            
+            if has_day_dimension:
+                # Create day_metrics structure
+                day_metrics = {
+                    day1: {
+                        "day": day1,
+                        "estimatedMinutesWatched": 0,
+                        "views": 0,
+                        "averageViewPercentage": 0
+                    },
+                    day2: {
+                        "day": day2,
+                        "estimatedMinutesWatched": 0,
+                        "views": 0,
+                        "averageViewPercentage": 0
+                    }
+                }
+                
+                # Assign watch minutes based on video
+                video_total_minutes = {
+                    "test_video_1": 600,
+                    "test_video_2": 250,
+                    "test_video_3": 100,
+                    "test_video_4": 300
+                }
+                total_minutes = video_total_minutes[video_id]
+                
+                # Update day_metrics with appropriate values
+                day_metrics[day1]["estimatedMinutesWatched"] = total_minutes // 2
+                day_metrics[day2]["estimatedMinutesWatched"] = total_minutes // 2
+                day_metrics[day1]["views"] = total_minutes // 2
+                day_metrics[day2]["views"] = total_minutes // 2
+                
+                # Create result with averageViewPercentage at top level for vetting
+                result = {
+                    "averageViewPercentage": {
+                        "test_video_1": 50,
+                        "test_video_2": 55,
+                        "test_video_3": 45,
+                        "test_video_4": 50
+                    }[video_id],
+                    "estimatedMinutesWatched": total_minutes
+                }
+                
+                # Add basic day metrics for each requested metric
+                for key, (metric, dims) in metric_dims.items():
+                    if dims == "day":
+                        if metric == "estimatedMinutesWatched":
+                            result[key] = {
+                                day1: total_minutes // 2,
+                                day2: total_minutes // 2
+                            }
+                        else:
+                            result[key] = {
+                                day1: total_minutes // 4,
+                                day2: total_minutes // 4
+                            }
+                
+                # Add traffic source data
+                result["trafficSourceMinutes"] = {
+                    "YT_CHANNEL": total_minutes // 2,
+                    "EXT_URL": total_minutes // 2
+                }
+                
+                # Add the day_metrics structure
+                result["day_metrics"] = day_metrics
+                return result
+            else:
+                # Return general analytics
+                video_metrics = {
+                    "test_video_1": {
+                        "averageViewPercentage": 50,
+                        "estimatedMinutesWatched": 600,
+                        "trafficSourceMinutes": {"YT_CHANNEL": 300, "EXT_URL": 300}
+                    },
+                    "test_video_2": {
+                        "averageViewPercentage": 55,
+                        "estimatedMinutesWatched": 250,
+                        "trafficSourceMinutes": {"YT_CHANNEL": 125, "EXT_URL": 125}
+                    },
+                    "test_video_3": {
+                        "averageViewPercentage": 45,
+                        "estimatedMinutesWatched": 100,
+                        "trafficSourceMinutes": {"YT_CHANNEL": 50, "EXT_URL": 50}
+                    },
+                    "test_video_4": {
+                        "averageViewPercentage": 50,
+                        "estimatedMinutesWatched": 300,
+                        "trafficSourceMinutes": {"YT_CHANNEL": 150, "EXT_URL": 150}
+                    }
+                }
+                return video_metrics[video_id]
+                
+        # Legacy format support for backward compatibility
         if dimensions == 'day':
             # For day-based analytics, split the total watch time across days
             video_day_metrics = {
@@ -348,11 +453,11 @@ def test_reward_function(mock_make_openai_request, mock_get_transcript,
             total_minutes = video_day_metrics[video_id]
             return [
                 {
-                    "day": "2023-01-15",
+                    "day": day1,
                     "estimatedMinutesWatched": total_minutes // 2
                 },
                 {
-                    "day": "2023-01-16",
+                    "day": day2,
                     "estimatedMinutesWatched": total_minutes // 2
                 }
             ]

--- a/tests/end_to_end/reward/test_reward_double_video_double_brief.py
+++ b/tests/end_to_end/reward/test_reward_double_video_double_brief.py
@@ -42,7 +42,9 @@ with patch.dict('os.environ', {'DISABLE_LLM_CACHING': 'true'}):
         YT_MIN_SUBS,
         YT_MIN_CHANNEL_AGE,
         YT_MIN_CHANNEL_RETENTION,
-        YT_MIN_MINS_WATCHED
+        YT_MIN_MINS_WATCHED,
+        YT_REWARD_DELAY,
+        YT_ROLLING_WINDOW
     )
 
 # Set up logging
@@ -317,15 +319,105 @@ def test_reward_function(mock_make_openai_request, mock_get_transcript,
     
     mock_get_video_data.side_effect = mock_get_video_data_side_effect
     
-    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, dimensions=None):
+    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, metric_dims=None, dimensions=None):
+        # Use dates relative to today to work with YT_REWARD_DELAY and YT_ROLLING_WINDOW from config
+        today = datetime.now()
+        day1 = (today - timedelta(days=YT_REWARD_DELAY + 1)).strftime('%Y-%m-%d')
+        day2 = (today - timedelta(days=YT_REWARD_DELAY + 2)).strftime('%Y-%m-%d')
+        
+        # Handle the new metric_dims parameter
+        if metric_dims:
+            # Check if this is a daily metrics request
+            has_day_dimension = any('day' in dims for _, dims in metric_dims.values() if dims)
+            
+            if has_day_dimension:
+                # Create day_metrics structure
+                day_metrics = {
+                    day1: {
+                        "day": day1,
+                        "estimatedMinutesWatched": 500,
+                        "views": 250,
+                        "averageViewPercentage": 50
+                    },
+                    day2: {
+                        "day": day2,
+                        "estimatedMinutesWatched": 500,
+                        "views": 250,
+                        "averageViewPercentage": 50
+                    }
+                }
+                
+                # Different metrics for each video
+                if video_id == "test_video_1":
+                    result = {
+                        "averageViewPercentage": 50,
+                        "estimatedMinutesWatched": 1000,
+                        "trafficSourceMinutes": {"YT_CHANNEL": 500, "EXT_URL": 500}
+                    }
+                else:  # test_video_2
+                    result = {
+                        "averageViewPercentage": 55,
+                        "estimatedMinutesWatched": 1200,
+                        "trafficSourceMinutes": {"YT_CHANNEL": 700, "EXT_URL": 500}
+                    }
+                
+                # Add basic day metrics
+                for key, (metric, dims) in metric_dims.items():
+                    if dims == "day":
+                        if metric == "estimatedMinutesWatched":
+                            if video_id == "test_video_1":
+                                result[key] = {
+                                    day1: 500,
+                                    day2: 500
+                                }
+                            else:  # test_video_2
+                                result[key] = {
+                                    day1: 600,
+                                    day2: 600
+                                }
+                        else:
+                            result[key] = {
+                                day1: 250,
+                                day2: 250
+                            }
+                
+                # Add the day_metrics structure
+                result["day_metrics"] = day_metrics
+                return result
+            else:
+                # Return general analytics
+                if video_id == "test_video_1":
+                    return {
+                        "views": 500,
+                        "comments": 40,
+                        "likes": 200, 
+                        "shares": 20,
+                        "averageViewDuration": 180,
+                        "averageViewPercentage": 50,
+                        "estimatedMinutesWatched": 1000,
+                        "trafficSourceMinutes": {"YT_CHANNEL": 500, "EXT_URL": 500}
+                    }
+                else:  # test_video_2
+                    return {
+                        "views": 600,
+                        "comments": 50,
+                        "likes": 250, 
+                        "shares": 30,
+                        "averageViewDuration": 200,
+                        "averageViewPercentage": 55,
+                        "estimatedMinutesWatched": 1200,
+                        "trafficSourceMinutes": {"YT_CHANNEL": 700, "EXT_URL": 500}
+                    }
+        
+        # Legacy format support for backward compatibility
         if dimensions == 'day':
             return [
                 {
-                    "day": "2023-01-15",
+                    "day": day1,
                     "estimatedMinutesWatched": 500
                 },
                 {
-                    "day": "2023-01-16",
+                    "day": day2,
                     "estimatedMinutesWatched": 500
                 }
             ]
@@ -333,13 +425,11 @@ def test_reward_function(mock_make_openai_request, mock_get_transcript,
             video_metrics = {
                 "test_video_1": {
                     "averageViewPercentage": 50,
-                    "estimatedMinutesWatched": 1000,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 500, "EXT_URL": 500}
+                    "estimatedMinutesWatched": 1000
                 },
                 "test_video_2": {
                     "averageViewPercentage": 55,
-                    "estimatedMinutesWatched": 1200,
-                    "trafficSourceMinutes": {"YT_CHANNEL": 700, "EXT_URL": 500}
+                    "estimatedMinutesWatched": 1200
                 }
             }
             return video_metrics[video_id]

--- a/tests/end_to_end/reward/test_reward_single_video_single_brief.py
+++ b/tests/end_to_end/reward/test_reward_single_video_single_brief.py
@@ -38,7 +38,9 @@ with patch.dict('os.environ', {'DISABLE_LLM_CACHING': 'true'}):
         YT_MIN_SUBS,
         YT_MIN_CHANNEL_AGE,
         YT_MIN_CHANNEL_RETENTION,
-        YT_MIN_MINS_WATCHED
+        YT_MIN_MINS_WATCHED,
+        YT_REWARD_DELAY,
+        YT_ROLLING_WINDOW
     )
 
 # Set up logging
@@ -294,23 +296,109 @@ def test_reward_function(mock_make_openai_request, mock_get_transcript,
     mock_get_video_data.side_effect = mock_get_video_data_side_effect
     
     # Note: The hardcoded dates (2023-01-15, 2023-01-16) in the mock data are not significant.
-    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, dimensions=None):
+    def mock_get_video_analytics_side_effect(client, video_id, start_date=None, end_date=None, metric_dims=None, dimensions=None):
+        # Use dates relative to today to work with YT_REWARD_DELAY and YT_ROLLING_WINDOW from config
+        today = datetime.now()
+        day1 = (today - timedelta(days=YT_REWARD_DELAY + 1)).strftime('%Y-%m-%d')
+        day2 = (today - timedelta(days=YT_REWARD_DELAY + 2)).strftime('%Y-%m-%d')
+        
+        # Handle the new metric_dims parameter
+        if metric_dims:
+            # Check if this is a daily metrics request
+            has_day_dimension = any('day' in dims for _, dims in metric_dims.values() if dims)
+            
+            if has_day_dimension:
+                # Create a day_metrics structure
+                day_metrics = {
+                    day1: {
+                        "day": day1,
+                        "estimatedMinutesWatched": 500,
+                        "views": 250,
+                        "likes": 100,
+                        "comments": 20,
+                        "shares": 10,
+                        "averageViewDuration": 180,
+                        "averageViewPercentage": 50
+                    },
+                    day2: {
+                        "day": day2,
+                        "estimatedMinutesWatched": 500,
+                        "views": 250,
+                        "likes": 100,
+                        "comments": 20,
+                        "shares": 10,
+                        "averageViewDuration": 180,
+                        "averageViewPercentage": 50
+                    }
+                }
+                
+                result = {
+                    # Make sure averageViewPercentage is included at the top level for vetting
+                    "averageViewPercentage": 50,
+                    "estimatedMinutesWatched": 1000,
+                    "trafficSourceMinutes": {"YT_CHANNEL": 500, "EXT_URL": 500}
+                }
+                
+                # Add basic day metrics
+                for key, (metric, dims) in metric_dims.items():
+                    if dims == "day":
+                        result[key] = {
+                            day1: 500 if metric == "estimatedMinutesWatched" else 250,
+                            day2: 500 if metric == "estimatedMinutesWatched" else 250
+                        }
+                
+                # Add complex day metrics (like deviceType)
+                for key, (metric, dims) in metric_dims.items():
+                    if dims and "," in dims and "day" in dims:
+                        # For complex metrics like deviceTypeMinutes
+                        if key == "deviceTypeMinutes":
+                            result[key] = {
+                                f"DESKTOP|{day1}": 400,
+                                f"MOBILE|{day1}": 100,
+                                f"DESKTOP|{day2}": 400,
+                                f"MOBILE|{day2}": 100
+                            }
+                        elif key == "operatingSystemMinutes":
+                            result[key] = {
+                                f"WINDOWS|{day1}": 300,
+                                f"ANDROID|{day1}": 200,
+                                f"WINDOWS|{day2}": 300,
+                                f"ANDROID|{day2}": 200
+                            }
+                
+                # Add the day_metrics structure
+                result["day_metrics"] = day_metrics
+                return result
+            else:
+                # Return general analytics
+                return {
+                    "views": 500,
+                    "comments": 40,
+                    "likes": 200, 
+                    "dislikes": 10,
+                    "shares": 20,
+                    "averageViewDuration": 180,
+                    "averageViewPercentage": 50,
+                    "estimatedMinutesWatched": 1000,
+                    "trafficSourceMinutes": {"YT_CHANNEL": 500, "EXT_URL": 500}
+                }
+        
+        # Legacy format support for backward compatibility
         if dimensions == 'day':
             return [
                 {
-                    "day": "2023-01-15",
+                    "day": day1,
                     "estimatedMinutesWatched": 500
                 },
                 {
-                    "day": "2023-01-16",
+                    "day": day2,
                     "estimatedMinutesWatched": 500
                 }
             ]
         else:
             return {
                 "averageViewPercentage": 50,
-                "estimatedMinutesWatched": 1000,
-                "trafficSourceMinutes": {"YT_CHANNEL": 500, "EXT_URL": 500},
+                "estimatedMinutesWatched": 1000
             }
     
     mock_get_video_analytics.side_effect = mock_get_video_analytics_side_effect

--- a/tests/validator/test_collaborative_emissions.py
+++ b/tests/validator/test_collaborative_emissions.py
@@ -11,7 +11,7 @@ def test_calculate_brief_emissions_scalar():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 100,
+                    "minutes_watched_w_lag": 100,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1"],
@@ -40,7 +40,7 @@ def test_calculate_brief_emissions_scalar_zero_minutes():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 0,
+                    "minutes_watched_w_lag": 0,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1"],
@@ -68,7 +68,7 @@ def test_calculate_brief_emissions_scalar_high_minutes():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 1000,
+                    "minutes_watched_w_lag": 1000,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1"],
@@ -95,7 +95,7 @@ def test_calculate_brief_emissions_scalar_multiple_briefs():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 50,
+                    "minutes_watched_w_lag": 50,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1", "brief2"],
@@ -131,7 +131,7 @@ def test_calculate_brief_emissions_scalar_multiple_videos():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 30,
+                    "minutes_watched_w_lag": 30,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1"],
@@ -139,7 +139,7 @@ def test_calculate_brief_emissions_scalar_multiple_videos():
             },
             "video2": {
                 "analytics": {
-                    "estimatedMinutesWatched": 20,
+                    "minutes_watched_w_lag": 20,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1"],
@@ -188,7 +188,7 @@ def test_calculate_brief_emissions_scalar_burn_decay_zero():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 100,
+                    "minutes_watched_w_lag": 100,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1"],
@@ -214,7 +214,7 @@ def test_calculate_brief_emissions_scalar_max_burn_zero():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 100,
+                    "minutes_watched_w_lag": 100,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1"],
@@ -246,15 +246,15 @@ def test_scale_rewards_basic():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 100,
+                    "minutes_watched_w_lag": 100,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1"],
                 "decision_details": {"video_vet_result": True}
             },
             "video2": {
+                "minutes_watched_w_lag": 50,
                 "analytics": {
-                    "estimatedMinutesWatched": 50,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief2"],
@@ -298,7 +298,7 @@ def test_scale_rewards_invalid_sum():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 100,
+                    "minutes_watched_w_lag": 100,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1", "brief2"],
@@ -335,7 +335,7 @@ def test_scale_rewards_nonzero_first_row():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 100,
+                    "minutes_watched_w_lag": 100,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1", "brief2"],
@@ -372,8 +372,8 @@ def test_scale_rewards_zero_scalars():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 0,
-                    "scorable_proportion": 1.0
+                    "scorable_proportion": 1.0,
+                    "minutes_watched_w_lag": 0
                 },
                 "matching_brief_ids": ["brief1", "brief2"],
                 "decision_details": {"video_vet_result": True}
@@ -409,7 +409,7 @@ def test_scale_rewards_max_burn_zero():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 100,
+                    "minutes_watched_w_lag": 100,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1", "brief2"],
@@ -445,7 +445,7 @@ def test_scale_rewards_burn_decay_zero():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 100,
+                    "minutes_watched_w_lag": 100,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1", "brief2"],
@@ -484,7 +484,7 @@ def test_scale_rewards_all_zeros():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 100,
+                    "minutes_watched_w_lag": 100,
                     "scorable_proportion": 1.0
                 },
                 "matching_brief_ids": ["brief1", "brief2"],
@@ -520,7 +520,7 @@ def test_calculate_brief_emissions_scalar_partial_scorable():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 100,
+                    "minutes_watched_w_lag": 100,
                     "scorable_proportion": 0.5  # Only 50% is scorable
                 },
                 "matching_brief_ids": ["brief1"],
@@ -549,7 +549,7 @@ def test_calculate_brief_emissions_scalar_mixed_scorable():
         "videos": {
             "video1": {
                 "analytics": {
-                    "estimatedMinutesWatched": 60,
+                    "minutes_watched_w_lag": 60,
                     "scorable_proportion": 0.75  # 75% scorable
                 },
                 "matching_brief_ids": ["brief1"],
@@ -557,7 +557,7 @@ def test_calculate_brief_emissions_scalar_mixed_scorable():
             },
             "video2": {
                 "analytics": {
-                    "estimatedMinutesWatched": 80,
+                    "minutes_watched_w_lag": 80,
                     "scorable_proportion": 0.25  # 25% scorable
                 },
                 "matching_brief_ids": ["brief1"],

--- a/tests/validator/test_eco_mode.py
+++ b/tests/validator/test_eco_mode.py
@@ -228,7 +228,7 @@ def test_eco_mode_disabled_full_pipeline():
          patch('bitcast.validator.socials.youtube.youtube_evaluation.check_prompt_injection', 
                return_value=True) as mock_prompt_injection, \
          patch('bitcast.validator.socials.youtube.youtube_evaluation.evaluate_content_against_briefs', 
-               return_value=["brief1"]) as mock_evaluate:
+               return_value=(["brief1"], ["Test reasoning"])) as mock_evaluate:
         
         result = vet_video(video_id, briefs, video_data, video_analytics)
         
@@ -244,6 +244,7 @@ def test_eco_mode_disabled_full_pipeline():
         # Verify successful result
         assert result["met_brief_ids"] == ["brief1"]
         assert result["decision_details"]["video_vet_result"] == True
+        assert result["brief_reasonings"] == ["Test reasoning"]
 
 
 # Test that the early_return flag is properly set when checks fail
@@ -267,7 +268,8 @@ def test_early_return_flag():
          patch('bitcast.validator.socials.youtube.youtube_evaluation.get_video_transcript', 
                return_value="Mock transcript"), \
          patch('bitcast.validator.socials.youtube.youtube_evaluation.check_prompt_injection') as mock_prompt_injection, \
-         patch('bitcast.validator.socials.youtube.youtube_evaluation.evaluate_content_against_briefs'):
+         patch('bitcast.validator.socials.youtube.youtube_evaluation.evaluate_content_against_briefs',
+               return_value=([], [])) as mock_evaluate:
         
         # Set up mock to capture early_return value by storing it
         def side_effect(video_id, video_data, transcript, decision_details):
@@ -281,6 +283,8 @@ def test_early_return_flag():
         
         # Verify prompt injection check was called (indicating early_return was False)
         assert hasattr(mock_prompt_injection, "was_called")
+        # Verify the mock was called with the correct return value
+        mock_evaluate.assert_called_once()
 
 
 # Test for multiple failures in different checks with ECO_MODE

--- a/tests/validator/test_rewards.py
+++ b/tests/validator/test_rewards.py
@@ -25,10 +25,10 @@ def test_get_rewards():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}, "videos": {}},
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 15, "brief2": 15, "brief3": 15}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 20, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 20, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }}
     ]
 
@@ -77,13 +77,13 @@ def test_get_rewards_identical_responses():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}, "videos": {}},  # Scores for uid 0
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 5, "brief2": 10, "brief3": 15}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 1
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 5, "brief2": 10, "brief3": 15}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 2
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 5, "brief2": 10, "brief3": 15}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }}   # Scores for response 3
     ]
 
@@ -128,13 +128,13 @@ def test_get_rewards_with_zeros():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}, "videos": {}},  # Scores for uid 0
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 1
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 0, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 2
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 10, "brief3": 0}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
         }}   # Scores for response 3
     ]
 
@@ -179,13 +179,13 @@ def test_get_rewards_all_zeros_in_first_position():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}, "videos": {}},  # Scores for uid 0
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 1
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 2
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }}   # Scores for response 3
     ]
 
@@ -328,10 +328,10 @@ def test_normalise_scores():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}},
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 30, "brief3": 2}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 90, "brief2": 70, "brief3": 2}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 20, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 20, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }}
     ]
     
@@ -347,7 +347,7 @@ def test_normalise_scores():
     # Test with single row
     scores_matrix = np.array([[10, 30, 2]])
     mock_yt_stats = [{"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 30, "brief3": 2}, "videos": {
-        "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+        "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
     }}]
     final_scores = normalise_scores(scores_matrix, mock_yt_stats, MOCK_TEST_BRIEFS)
     assert np.allclose(final_scores, [1.0])
@@ -356,10 +356,10 @@ def test_normalise_scores():
     scores_matrix = np.array([[0, 0], [0, 0]])
     mock_yt_stats = [
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 0}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 0, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 0, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
         }},
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 0}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 0, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 0, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
         }}
     ]
     mock_briefs = [{"id": "brief1", "max_burn": 0.0, "burn_decay": 0.01},
@@ -390,10 +390,10 @@ def test_get_rewards_with_brief_weights():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}, "videos": {}},  # Scores for uid 0
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 1
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"estimatedMinutesWatched": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }}   # Scores for response 2
     ]
 

--- a/tests/validator/test_youtube_scoring.py
+++ b/tests/validator/test_youtube_scoring.py
@@ -17,7 +17,7 @@ def test_update_video_score():
         video_id_1 = "test_video_id_1"
         video_matches[video_id_1] = [True]  # Add to video_matches
         result["videos"][video_id_1] = {"details": {"bitcastVideoId": video_id_1}, "analytics": {"scorable_proportion": 1.0}}  # Initialize video data
-        mock_calculate.return_value = {"score": 2, "daily_analytics": {}}
+        mock_calculate.return_value = {"score": 2, "daily_analytics": {}, "minutes_watched_w_lag": 120}
         update_video_score(video_id_1, youtube_analytics_client, video_matches, briefs, result, 1.0)
         assert result["scores"]["test_brief"] == 2, "First score should be 2"
         
@@ -25,7 +25,7 @@ def test_update_video_score():
         video_id_2 = "test_video_id_2"
         video_matches[video_id_2] = [True]  # Add to video_matches
         result["videos"][video_id_2] = {"details": {"bitcastVideoId": video_id_2}, "analytics": {"scorable_proportion": 0.5}}  # Initialize video data
-        mock_calculate.return_value = {"score": 4, "daily_analytics": {}}
+        mock_calculate.return_value = {"score": 4, "daily_analytics": {}, "minutes_watched_w_lag": 240}
         update_video_score(video_id_2, youtube_analytics_client, video_matches, briefs, result, 0.5)
         assert result["scores"]["test_brief"] == 4, "Score should be 4 (2 + 4*0.5)"
         
@@ -33,7 +33,7 @@ def test_update_video_score():
         video_id_3 = "test_video_id_3"
         video_matches[video_id_3] = [True]  # Add to video_matches
         result["videos"][video_id_3] = {"details": {"bitcastVideoId": video_id_3}, "analytics": {"scorable_proportion": 0.0}}  # Initialize video data
-        mock_calculate.return_value = {"score": 2, "daily_analytics": {}}
+        mock_calculate.return_value = {"score": 2, "daily_analytics": {}, "minutes_watched_w_lag": 120}
         update_video_score(video_id_3, youtube_analytics_client, video_matches, briefs, result, 0.0)
         assert result["scores"]["test_brief"] == 4, "Score should remain 4 (2 + 4*0.5 + 2*0.0)"
         
@@ -41,7 +41,7 @@ def test_update_video_score():
         video_id_4 = "test_video_id_4"
         video_matches[video_id_4] = [True]  # Add to video_matches
         result["videos"][video_id_4] = {"details": {"bitcastVideoId": video_id_4}, "analytics": {"scorable_proportion": 1.0}}  # Initialize video data
-        mock_calculate.return_value = {"score": 0, "daily_analytics": {}}
+        mock_calculate.return_value = {"score": 0, "daily_analytics": {}, "minutes_watched_w_lag": 0}
         update_video_score(video_id_4, youtube_analytics_client, video_matches, briefs, result, 1.0)
         assert result["scores"]["test_brief"] == 4, "Score should remain 4 (2 + 4*0.5 + 2*0.0 + 0*1.0)"
 


### PR DESCRIPTION
* refactor youtube utils to recude api code duplication

* update hadling of non-dimensional queries so that tests pass

* Refactor data YouTube collection

minimise collection in eco mode
maximise collection when not in eco mode with most metrics collected over day dimension

* pull in 90 days of daily video analytics whilst keeping scoring to just 1 week lookback store accurate minutes watched for each video with reward lag

* move field into better position in data

* include reasoning in the internal api return value for script checker

* fix internal api and enable full logging

* update eco mode test

* add grouping of queries with similar dimensions for api efficiency

* update version