### PR TITLE
V 1.4.3 (#40)

### DIFF
--- a/bitcast/utils/uids.py
+++ b/bitcast/utils/uids.py
@@ -27,21 +27,18 @@ def check_uid_availability(
 
 
 def get_all_uids(self, exclude: List[int] = None) -> np.ndarray:
-    """Returns all available uids from the metagraph.
+    """Returns all uids from the metagraph, excluding specified ones.
     Args:
         exclude (List[int]): List of uids to exclude from the result.
     Returns:
-        uids (np.ndarray): All available uids.
+        uids (np.ndarray): All uids excluding specified ones.
     """
     avail_uids = []
 
     for uid in range(self.metagraph.n.item()):
-        uid_is_available = check_uid_availability(
-            self.metagraph, uid, self.config.neuron.vpermit_tao_limit
-        )
         uid_is_not_excluded = exclude is None or uid not in exclude
 
-        if uid_is_available and uid_is_not_excluded:
+        if uid_is_not_excluded:
             avail_uids.append(uid)
 
     # Ensure uid 0 is always included at the start of the list

--- a/bitcast/validator/forward.py
+++ b/bitcast/validator/forward.py
@@ -20,7 +20,6 @@
 import time
 import bittensor as bt
 
-from bitcast.protocol import AccessTokenSynapse
 from bitcast.validator.reward import get_rewards
 from bitcast.utils.uids import get_all_uids
 from bitcast.validator.utils.publish_stats import publish_stats
@@ -41,20 +40,10 @@ async def forward(self):
 
         miner_uids = get_all_uids(self)
 
-        # The dendrite client queries the network.
-        responses = await self.dendrite(
-            # Send the query to selected miner axons in the network.
-            axons=[self.metagraph.axons[uid] for uid in miner_uids],
-            # Request an access token from miners
-            synapse=AccessTokenSynapse(),
-            # Don't deserialize the responses to get the AccessTokenSynapse objects directly
-            deserialize=False,
-        )
+        bt.logging.info(f"Number of miners to query: {len(miner_uids)}")
 
-        bt.logging.info(f"Number of responses received: {len(responses)}")
-
-        # Get rewards for the responses
-        rewards, yt_stats_list = get_rewards(self, miner_uids, responses=responses)
+        # Get rewards for the responses - now queries miners individually
+        rewards, yt_stats_list = await get_rewards(self, miner_uids)
 
         # Log the rewards for monitoring purposes
         bt.logging.info("UID Rewards:")

--- a/bitcast/validator/rewards_scaling.py
+++ b/bitcast/validator/rewards_scaling.py
@@ -36,12 +36,11 @@ def calculate_brief_emissions_scalar(yt_stats_list: List[dict], briefs: List[dic
                             if not decision_details.get("video_vet_result", False):
                                 continue
 
-                            minutes = float(video_data.get("analytics", {}).get("minutes_watched_w_lag", 0))
-                            scorable_proportion = float(video_data.get("analytics", {}).get("scorable_proportion", 0))
+                            minutes = float(video_data.get("analytics", {}).get("scorableHistoryMins", 0))
                             
                             matching_briefs = video_data.get("matching_brief_ids", [])
                             for brief_id in matching_briefs:
-                                brief_total_minutes[brief_id] = brief_total_minutes.get(brief_id, 0) + (minutes * scorable_proportion)
+                                brief_total_minutes[brief_id] = brief_total_minutes.get(brief_id, 0) + (minutes)
         except Exception as e:
             bt.logging.warning(f"Error processing stats: {e}")
             continue

--- a/bitcast/validator/socials/youtube/config.py
+++ b/bitcast/validator/socials/youtube/config.py
@@ -29,6 +29,7 @@ ADDITIONAL_METRICS = {
 # Core daily metrics - all metrics with day dimension
 CORE_DAILY_METRICS = {
     "estimatedMinutesWatched": ("estimatedMinutesWatched", "day"),
+    "trafficSourceMinutes": ("estimatedMinutesWatched", "insightTrafficSourceType,day"),
 }
 
 # Additional daily metrics for ECO_MODE
@@ -39,7 +40,6 @@ ADDITIONAL_DAILY_METRICS = {
     "shares": ("shares", "day"),
     "averageViewDuration": ("averageViewDuration", "day"),
     "AverageViewPercentage": ("averageViewPercentage", "day"),
-    "trafficSourceMinutes": ("estimatedMinutesWatched", "insightTrafficSourceType,day"),
     "deviceTypeMinutes": ("estimatedMinutesWatched", "deviceType,day"),
     "operatingSystemMinutes": ("estimatedMinutesWatched", "operatingSystem,day"),
     "creatorContentTypeMinutes": ("estimatedMinutesWatched", "creatorContentType,day"),

--- a/bitcast/validator/socials/youtube/youtube_scoring.py
+++ b/bitcast/validator/socials/youtube/youtube_scoring.py
@@ -151,7 +151,7 @@ def process_single_video(video_id, video_data_dict, video_analytics_dict, video_
     
     # Calculate and store the score if the video passes vetting and matches a brief
     if video_vet_result and matches_any_brief:
-        update_video_score(video_id, youtube_analytics_client, video_matches, briefs, result, video_analytics.get("scorable_proportion", 0))
+        update_video_score(video_id, youtube_analytics_client, video_matches, briefs, result)
     else:
         result["videos"][video_id]["score"] = 0
 
@@ -167,27 +167,22 @@ def check_video_brief_matches(video_id, video_matches, briefs):
     
     return matches_any_brief, matching_brief_ids
 
-def update_video_score(video_id, youtube_analytics_client, video_matches, briefs, result, scorable_proportion):
+def update_video_score(video_id, youtube_analytics_client, video_matches, briefs, result):
     """Calculate and update the score for a video that matches a brief."""
     video_score_result = calculate_video_score(video_id, youtube_analytics_client)
     video_score = video_score_result["score"]
     bt.logging.info(f"Raw video_score from calculate_video_score: {video_score}")
     
-    # Scale the score by the scorable proportion
-    scaled_score = video_score * scorable_proportion
-    bt.logging.info(f"Scaled score (video_score * scorable_proportion): {scaled_score}")
-    
-    result["videos"][video_id]["raw_score"] = video_score
-    result["videos"][video_id]["score"] = scaled_score
-    result["videos"][video_id]["analytics"]["minutes_watched_w_lag"] = video_score_result["minutes_watched_w_lag"]
+    result["videos"][video_id]["score"] = video_score
+    result["videos"][video_id]["analytics"]["scorableHistoryMins"] = video_score_result["scorableHistoryMins"]
     result["videos"][video_id]["daily_analytics"] = video_score_result["daily_analytics"]
     
     # Update the score for the matching brief
     for i, match in enumerate(video_matches.get(video_id, [])):
         if match:
             brief_id = briefs[i]["id"]
-            result["scores"][brief_id] += scaled_score
-            bt.logging.info(f"Brief: {brief_id}, Video: {result['videos'][video_id]['details']['bitcastVideoId']}, Score: {scaled_score}")
+            result["scores"][brief_id] += video_score
+            bt.logging.info(f"Brief: {brief_id}, Video: {result['videos'][video_id]['details']['bitcastVideoId']}, Score: {video_score}")
 
 def check_subscriber_range(sub_count, subs_range):
     """

--- a/bitcast/validator/socials/youtube/youtube_utils.py
+++ b/bitcast/validator/socials/youtube/youtube_utils.py
@@ -450,7 +450,7 @@ def _fetch_transcript(video_id, rapid_api_key):
     url = "https://youtube-transcriptor.p.rapidapi.com/transcript"
     headers = {"x-rapidapi-key": rapid_api_key, "x-rapidapi-host": "youtube-transcriptor.p.rapidapi.com"}
     querystring = {"video_id": video_id}
-    response = requests.get(url, headers=headers, params=querystring, timeout=10)
+    response = requests.get(url, headers=headers, params=querystring, timeout=5)
     response.raise_for_status()
     transcript_data = response.json()
 

--- a/bitcast/validator/utils/config.py
+++ b/bitcast/validator/utils/config.py
@@ -15,7 +15,7 @@ CACHE_DIRS = {
     "blacklist": os.path.join(CACHE_ROOT, "blacklist")
 }
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 
 # required
 BITCAST_SERVER_URL = os.getenv('BITCAST_SERVER_URL', 'http://44.227.253.127')

--- a/tests/validator/test_rewards.py
+++ b/tests/validator/test_rewards.py
@@ -25,10 +25,10 @@ def test_get_rewards():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}, "videos": {}},
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 15, "brief2": 15, "brief3": 15}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 20, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 20}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }}
     ]
 
@@ -77,13 +77,13 @@ def test_get_rewards_identical_responses():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}, "videos": {}},  # Scores for uid 0
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 5, "brief2": 10, "brief3": 15}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 1
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 5, "brief2": 10, "brief3": 15}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 2
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 5, "brief2": 10, "brief3": 15}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }}   # Scores for response 3
     ]
 
@@ -128,13 +128,13 @@ def test_get_rewards_with_zeros():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}, "videos": {}},  # Scores for uid 0
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 1
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 0, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief1", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 2
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 10, "brief3": 0}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
         }}   # Scores for response 3
     ]
 
@@ -179,13 +179,13 @@ def test_get_rewards_all_zeros_in_first_position():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}, "videos": {}},  # Scores for uid 0
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 1
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 2
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }}   # Scores for response 3
     ]
 
@@ -328,10 +328,10 @@ def test_normalise_scores():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}},
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 30, "brief3": 2}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 90, "brief2": 70, "brief3": 2}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 20, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 20}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }}
     ]
     
@@ -347,7 +347,7 @@ def test_normalise_scores():
     # Test with single row
     scores_matrix = np.array([[10, 30, 2]])
     mock_yt_stats = [{"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 30, "brief3": 2}, "videos": {
-        "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+        "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
     }}]
     final_scores = normalise_scores(scores_matrix, mock_yt_stats, MOCK_TEST_BRIEFS)
     assert np.allclose(final_scores, [1.0])
@@ -356,10 +356,10 @@ def test_normalise_scores():
     scores_matrix = np.array([[0, 0], [0, 0]])
     mock_yt_stats = [
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 0}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 0, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 0}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
         }},
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 0, "brief2": 0}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 0, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 0}, "matching_brief_ids": ["brief1", "brief2"], "decision_details": {"video_vet_result": True}}
         }}
     ]
     mock_briefs = [{"id": "brief1", "max_burn": 0.0, "burn_decay": 0.01},
@@ -390,10 +390,10 @@ def test_get_rewards_with_brief_weights():
     mock_yt_stats = [
         {"scores": {"brief1": 0, "brief2": 0, "brief3": 0}, "videos": {}},  # Scores for uid 0
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }},  # Scores for response 1
         {"yt_account": {"channel_vet_result": True}, "scores": {"brief1": 10, "brief2": 10, "brief3": 10}, "videos": {
-            "video1": {"analytics": {"minutes_watched_w_lag": 10, "scorable_proportion": 1.0}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
+            "video1": {"analytics": {"scorableHistoryMins": 10}, "matching_brief_ids": ["brief1", "brief2", "brief3"], "decision_details": {"video_vet_result": True}}
         }}   # Scores for response 2
     ]
 


### PR DESCRIPTION
* remove scorable proportion in favour of working out exact proportions per day

* query miners before evaluating them rather than all at the start to ensure tokens do not expire

* reduce transcript api timeout to speed up validation

* remove availability check on uids it was excluding some available miners

* update version