### PR TITLE
V 1.4.5 (#45)

### DIFF
--- a/bitcast/validator/socials/youtube/config.py
+++ b/bitcast/validator/socials/youtube/config.py
@@ -3,50 +3,85 @@ YouTube analytics metrics and configuration.
 
 This file contains configurations for different types of YouTube analytics metrics
 used for evaluating and scoring videos.
+
+Metric format: (metric_name, dimensions, filter, maxResults, sort)
+- metric_name: The YouTube Analytics API metric
+- dimensions: Comma-separated dimensions for grouping
+- filter: Optional filter to apply to this specific metric (None if no filter)
+- maxResults: Optional maximum number of results to return (None for default)
+- sort: Optional sort parameter for ordering results (None for default)
+
+Example usage:
+    # Basic usage with additional filter
+    metrics = get_youtube_metrics(eco_mode=False, for_daily=True)
+    analytics = get_video_analytics(
+        client, video_id, 
+        metric_dims=metrics,
+        filters="country==US"  # Only get data for US
+    )
+    
+    # Multiple filters
+    analytics = get_video_analytics(
+        client, video_id,
+        metric_dims=metrics, 
+        filters="country==US;deviceType==MOBILE"
+    )
 """
 
 # Core metrics for general analytics
 CORE_METRICS = {
-    "averageViewPercentage": ("averageViewPercentage", ""),
-    "estimatedMinutesWatched": ("estimatedMinutesWatched", ""),
-    "trafficSourceMinutes": ("estimatedMinutesWatched", "insightTrafficSourceType"),
+    "averageViewPercentage": ("averageViewPercentage", "", None, None, None),
+    "estimatedMinutesWatched": ("estimatedMinutesWatched", "", None, None, None),
+    "trafficSourceMinutes": ("estimatedMinutesWatched", "insightTrafficSourceType", None, None, None),
 }
 
 # Additional metrics for full analytics (when not in ECO_MODE)
 ADDITIONAL_METRICS = {
-    "views": ("views", ""),
-    "comments": ("comments", ""),
-    "likes": ("likes", ""),
-    "dislikes": ("dislikes", ""),
-    "shares": ("shares", ""),
-    "averageViewDuration": ("averageViewDuration", ""),
-    "countryMinutes": ("estimatedMinutesWatched", "country"),
-    "ageGroupViewerPercentage": ("viewerPercentage", "ageGroup,gender"),
-    "elapsedVideoTimeRatioAudienceWatchRatio": ("audienceWatchRatio", "elapsedVideoTimeRatio"),
-    "sharingServiceShares": ("shares", "sharingService")
+    "views": ("views", "", None, None, None),
+    "comments": ("comments", "", None, None, None),
+    "likes": ("likes", "", None, None, None),
+    "dislikes": ("dislikes", "", None, None, None),
+    "shares": ("shares", "", None, None, None),
+    "averageViewDuration": ("averageViewDuration", "", None, None, None),
+    "countryMinutes": ("estimatedMinutesWatched", "country", None, None, "-estimatedMinutesWatched"),
+    "ageGroupViewerPercentage": ("viewerPercentage", "ageGroup,gender", None, None, None),
+    "elapsedVideoTimeRatioAudienceWatchRatio": ("audienceWatchRatio", "elapsedVideoTimeRatio", None, None, None),
+    "sharingServiceShares": ("shares", "sharingService", None, None, "-shares"),
+
+    "relativeRetentionPerformance": ("relativeRetentionPerformance", "elapsedVideoTimeRatio", None, None, None),
+    "insightTrafficSourceDetail_EXT_URL": ("estimatedMinutesWatched", "insightTrafficSourceDetail", "insightTrafficSourceType==EXT_URL", 10, "-estimatedMinutesWatched"),
+    #"insightTrafficSourceDetail_YT_SEARCH": ("estimatedMinutesWatched", "insightTrafficSourceDetail", "insightTrafficSourceType==YT_SEARCH", 10, "-estimatedMinutesWatched"),
+    #"insightTrafficSourceDetail_RELATED_VIDEO": ("estimatedMinutesWatched", "insightTrafficSourceDetail", "insightTrafficSourceType==RELATED_VIDEO", 10, "-estimatedMinutesWatched"),
+    #"insightTrafficSourceDetail_YT_CHANNEL": ("estimatedMinutesWatched", "insightTrafficSourceDetail", "insightTrafficSourceType==YT_CHANNEL", 10, "-estimatedMinutesWatched"),
+    "creatorContentTypeMinutes": ("estimatedMinutesWatched", "creatorContentType", None, None, None),
+    "subscribedStatusMinutes": ("averageViewPercentage", "subscribedStatus", None, None, None),
+
 }
 
 # Core daily metrics - all metrics with day dimension
 CORE_DAILY_METRICS = {
-    "estimatedMinutesWatched": ("estimatedMinutesWatched", "day"),
-    "trafficSourceMinutes": ("estimatedMinutesWatched", "insightTrafficSourceType,day"),
+    "estimatedMinutesWatched": ("estimatedMinutesWatched", "day", None, None, "day"),
+    "trafficSourceMinutes": ("estimatedMinutesWatched", "insightTrafficSourceType,day", None, None, "day"),
 }
 
 # Additional daily metrics for ECO_MODE
 ADDITIONAL_DAILY_METRICS = {
-    "views": ("views", "day"),
-    "comments": ("comments", "day"),
-    "likes": ("likes", "day"),
-    "shares": ("shares", "day"),
-    "averageViewDuration": ("averageViewDuration", "day"),
-    "AverageViewPercentage": ("averageViewPercentage", "day"),
-    "deviceTypeMinutes": ("estimatedMinutesWatched", "deviceType,day"),
-    "operatingSystemMinutes": ("estimatedMinutesWatched", "operatingSystem,day"),
-    "creatorContentTypeMinutes": ("estimatedMinutesWatched", "creatorContentType,day"),
-    "playbackLocationMinutes": ("estimatedMinutesWatched", "insightPlaybackLocationType,day"),
-    "avgViewPercentageByTrafficSource": ("averageViewPercentage", "insightTrafficSourceType,day"),
-    "liveOrOnDemandMinutes": ("estimatedMinutesWatched", "liveOrOnDemand,day"),
-    "youtubeProductMinutes": ("estimatedMinutesWatched", "youtubeProduct,day"),
+    "views": ("views", "day", None, None, "day"),
+    "comments": ("comments", "day", None, None, "day"),
+    "likes": ("likes", "day", None, None, "day"),
+    "shares": ("shares", "day", None, None, "day"),
+    "averageViewDuration": ("averageViewDuration", "day", None, None, "day"),
+    "AverageViewPercentage": ("averageViewPercentage", "day", None, None, "day"),
+    "deviceTypeMinutes": ("estimatedMinutesWatched", "deviceType,day", None, None, "day"),
+    "operatingSystemMinutes": ("estimatedMinutesWatched", "operatingSystem,day", None, None, "day"),
+    "creatorContentTypeMinutes": ("estimatedMinutesWatched", "creatorContentType,day", None, None, "day"),
+    "playbackLocationMinutes": ("estimatedMinutesWatched", "insightPlaybackLocationType,day", None, None, "day"),
+    "avgViewPercentageByTrafficSource": ("averageViewPercentage", "insightTrafficSourceType,day", None, None, "day"),
+    "liveOrOnDemandMinutes": ("estimatedMinutesWatched", "liveOrOnDemand,day", None, None, "day"),
+    "youtubeProductMinutes": ("estimatedMinutesWatched", "youtubeProduct,day", None, None, "day"),
+
+    "engagedViews": ("engagedViews", "day", None, None, "day"),
+    "videosAddedToPlaylists": ("videosAddedToPlaylists", "day", None, None, "day"),
 }
 
 def get_youtube_metrics(eco_mode, for_daily=False):
@@ -58,7 +93,15 @@ def get_youtube_metrics(eco_mode, for_daily=False):
         eco_mode: Whether to use ECO_MODE metrics (reduced set)
         
     Returns:
-        Dictionary of metric dimensions for YouTube API calls
+        Dictionary of metric configurations in format: {key: (metric, dimensions, filter, maxResults, sort)}
+        
+    Example:
+        metrics = get_youtube_metrics(eco_mode=False, for_daily=True)
+        analytics = get_video_analytics(
+            client, video_id,
+            metric_dims=metrics,
+            filters="country==US;deviceType==MOBILE"
+        )
     """
     if for_daily and eco_mode:
         return CORE_DAILY_METRICS

--- a/bitcast/validator/socials/youtube/youtube_scoring.py
+++ b/bitcast/validator/socials/youtube/youtube_scoring.py
@@ -169,7 +169,9 @@ def check_video_brief_matches(video_id, video_matches, briefs):
 
 def update_video_score(video_id, youtube_analytics_client, video_matches, briefs, result):
     """Calculate and update the score for a video that matches a brief."""
-    video_score_result = calculate_video_score(video_id, youtube_analytics_client)
+    video_publish_date = result["videos"][video_id]["details"].get("publishedAt")
+    
+    video_score_result = calculate_video_score(video_id, youtube_analytics_client, video_publish_date)
     video_score = video_score_result["score"]
     bt.logging.info(f"Raw video_score from calculate_video_score: {video_score}")
     

--- a/bitcast/validator/utils/config.py
+++ b/bitcast/validator/utils/config.py
@@ -15,7 +15,7 @@ CACHE_DIRS = {
     "blacklist": os.path.join(CACHE_ROOT, "blacklist")
 }
 
-__version__ = "1.4.3"
+__version__ = "1.4.5"
 
 # required
 BITCAST_SERVER_URL = os.getenv('BITCAST_SERVER_URL', 'http://44.227.253.127')

--- a/tests/end_to_end/get_rewards/test_complex_scenario.py
+++ b/tests/end_to_end/get_rewards/test_complex_scenario.py
@@ -240,6 +240,7 @@ def reset_scored_videos():
     reset_func()
     yield
 
+@pytest.mark.asyncio
 @patch('bitcast.validator.socials.youtube.youtube_scoring.build')
 @patch('bitcast.validator.utils.blacklist.get_blacklist')
 @patch('bitcast.validator.socials.youtube.youtube_utils.get_channel_data')
@@ -250,7 +251,7 @@ def reset_scored_videos():
 @patch('bitcast.validator.socials.youtube.youtube_utils.get_video_transcript')
 @patch('bitcast.validator.clients.OpenaiClient._make_openai_request')
 @patch('bitcast.validator.utils.config.DISABLE_LLM_CACHING', True)
-def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
+async def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
                         mock_get_video_analytics, mock_get_video_data, mock_get_all_uploads, 
                         mock_get_channel_analytics, mock_get_channel_data, mock_get_blacklist, mock_build):
     """Test the get_rewards function end-to-end with a single miner and UID 0"""
@@ -292,6 +293,10 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
     mock_response_2.YT_channel_id = "test_channel_uid2"  # Add channel ID for UID 2
     
     responses = [mock_response_0, mock_response_1, mock_response_2]
+    
+    # Mock query_miner to return responses based on UID
+    async def mock_query_miner(self, uid):
+        return responses[uid]
     
     youtube_data_client, youtube_analytics_client = get_mock_youtube_clients()
     
@@ -507,7 +512,8 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
             }
             
             # Add metrics for each requested metric
-            for key, (metric, dims) in metric_dims.items():
+            for key, metric_config in metric_dims.items():
+                metric, dims = metric_config[0], metric_config[1]  # Extract metric and dims from 5-tuple
                 if dims == "day":
                     if metric == "estimatedMinutesWatched":
                         result[key] = {
@@ -615,11 +621,12 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
     mock_self = MagicMock()
     
     # Patch get_briefs to return our test briefs
-    with patch('bitcast.validator.reward.get_briefs', return_value=briefs) as mock_get_briefs:
+    with patch('bitcast.validator.reward.get_briefs', return_value=briefs) as mock_get_briefs, \
+         patch('bitcast.validator.reward.query_miner', side_effect=mock_query_miner) as mock_query_miner_patch:
         # Create a wrapper around the reward function that resets scored videos between each UID
         with patch('bitcast.validator.reward.reward', side_effect=reward_wrapper):
             # Call get_rewards
-            result, yt_stats_list = get_rewards(mock_self, uids, responses)
+            result, yt_stats_list = await get_rewards(mock_self, uids)
         
         # Verify the result is a numpy array
         assert isinstance(result, np.ndarray)
@@ -635,6 +642,9 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
         
         # Verify that get_briefs was called
         mock_get_briefs.assert_called_once()
+        
+        # Verify that query_miner was called for each UID
+        assert mock_query_miner_patch.call_count == 3
         
         # Verify that yt_stats_list is returned
         assert isinstance(yt_stats_list, list)

--- a/tests/end_to_end/get_rewards/test_complex_scenario_with_scorable_proportion.py
+++ b/tests/end_to_end/get_rewards/test_complex_scenario_with_scorable_proportion.py
@@ -248,6 +248,7 @@ def reset_scored_videos():
     reset_func()
     yield
 
+@pytest.mark.asyncio
 @patch('bitcast.validator.socials.youtube.youtube_scoring.build')
 @patch('bitcast.validator.utils.blacklist.get_blacklist')
 @patch('bitcast.validator.socials.youtube.youtube_utils.get_channel_data')
@@ -258,7 +259,7 @@ def reset_scored_videos():
 @patch('bitcast.validator.socials.youtube.youtube_utils.get_video_transcript')
 @patch('bitcast.validator.clients.OpenaiClient._make_openai_request')
 @patch('bitcast.validator.utils.config.DISABLE_LLM_CACHING', True)
-def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
+async def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
                         mock_get_video_analytics, mock_get_video_data, mock_get_all_uploads, 
                         mock_get_channel_analytics, mock_get_channel_data, mock_get_blacklist, mock_build):
     """Test the get_rewards function end-to-end with a single miner and UID 0"""
@@ -532,7 +533,8 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
             }
             
             # Add metrics for each requested metric
-            for key, (metric, dims) in metric_dims.items():
+            for key, metric_config in metric_dims.items():
+                metric, dims = metric_config[0], metric_config[1]  # Extract metric and dims from 5-tuple
                 if dims == "day":
                     if metric == "estimatedMinutesWatched":
                         result[key] = {
@@ -690,12 +692,18 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
     # Create a mock class instance for self parameter
     mock_self = MagicMock()
     
+    # Create mock_query_miner function that returns responses based on UID
+    async def mock_query_miner(self, uid):
+        return responses[uid]
+    
     # Patch get_briefs to return our test briefs
     with patch('bitcast.validator.reward.get_briefs', return_value=briefs) as mock_get_briefs:
         # Create a wrapper around the reward function that resets scored videos between each UID
         with patch('bitcast.validator.reward.reward', side_effect=reward_wrapper):
-            # Call get_rewards
-            result, yt_stats_list = get_rewards(mock_self, uids, responses)
+            # Patch query_miner to return our mock responses
+            with patch('bitcast.validator.reward.query_miner', side_effect=mock_query_miner) as mock_query_miner_patch:
+                # Call get_rewards
+                result, yt_stats_list = await get_rewards(mock_self, uids)
         
         # Verify that the result is a numpy array
         assert isinstance(result, np.ndarray)
@@ -713,6 +721,9 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
         
         # Verify that get_briefs was called
         mock_get_briefs.assert_called_once()
+        
+        # Verify that query_miner was called for each UID
+        assert mock_query_miner_patch.call_count == 3
         
         # Verify that yt_stats_list is returned
         assert isinstance(yt_stats_list, list)

--- a/tests/end_to_end/get_rewards/test_complex_scenario_with_weights.py
+++ b/tests/end_to_end/get_rewards/test_complex_scenario_with_weights.py
@@ -240,6 +240,7 @@ def reset_scored_videos():
     reset_func()
     yield
 
+@pytest.mark.asyncio
 @patch('bitcast.validator.socials.youtube.youtube_scoring.build')
 @patch('bitcast.validator.utils.blacklist.get_blacklist')
 @patch('bitcast.validator.socials.youtube.youtube_utils.get_channel_data')
@@ -250,7 +251,7 @@ def reset_scored_videos():
 @patch('bitcast.validator.socials.youtube.youtube_utils.get_video_transcript')
 @patch('bitcast.validator.clients.OpenaiClient._make_openai_request')
 @patch('bitcast.validator.utils.config.DISABLE_LLM_CACHING', True)
-def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
+async def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
                         mock_get_video_analytics, mock_get_video_data, mock_get_all_uploads, 
                         mock_get_channel_analytics, mock_get_channel_data, mock_get_blacklist, mock_build):
     """Test the get_rewards function end-to-end with a single miner and UID 0"""
@@ -507,7 +508,8 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
             }
             
             # Add metrics for each requested metric
-            for key, (metric, dims) in metric_dims.items():
+            for key, metric_config in metric_dims.items():
+                metric, dims = metric_config[0], metric_config[1]  # Extract metric and dims from 5-tuple
                 if dims == "day":
                     if metric == "estimatedMinutesWatched":
                         result[key] = {
@@ -614,12 +616,18 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
     # Create a mock class instance for self parameter
     mock_self = MagicMock()
     
+    # Create mock_query_miner function that returns responses based on UID
+    async def mock_query_miner(self, uid):
+        return responses[uid]
+    
     # Patch get_briefs to return our test briefs
     with patch('bitcast.validator.reward.get_briefs', return_value=briefs) as mock_get_briefs:
         # Create a wrapper around the reward function that resets scored videos between each UID
         with patch('bitcast.validator.reward.reward', side_effect=reward_wrapper):
-            # Call get_rewards
-            result, yt_stats_list = get_rewards(mock_self, uids, responses)
+            # Patch query_miner to return our mock responses
+            with patch('bitcast.validator.reward.query_miner', side_effect=mock_query_miner) as mock_query_miner_patch:
+                # Call get_rewards
+                result, yt_stats_list = await get_rewards(mock_self, uids)
         
         # Verify the result is a numpy array
         assert isinstance(result, np.ndarray)
@@ -634,6 +642,9 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
         
         # Verify that get_briefs was called
         mock_get_briefs.assert_called_once()
+        
+        # Verify that query_miner was called for each UID
+        assert mock_query_miner_patch.call_count == 3
         
         # Verify that yt_stats_list is returned
         assert isinstance(yt_stats_list, list)

--- a/tests/end_to_end/get_rewards/test_complex_scenario_with_weights_and_burn.py
+++ b/tests/end_to_end/get_rewards/test_complex_scenario_with_weights_and_burn.py
@@ -240,6 +240,7 @@ def reset_scored_videos():
     reset_func()
     yield
 
+@pytest.mark.asyncio
 @patch('bitcast.validator.socials.youtube.youtube_scoring.build')
 @patch('bitcast.validator.utils.blacklist.get_blacklist')
 @patch('bitcast.validator.socials.youtube.youtube_utils.get_channel_data')
@@ -250,7 +251,7 @@ def reset_scored_videos():
 @patch('bitcast.validator.socials.youtube.youtube_utils.get_video_transcript')
 @patch('bitcast.validator.clients.OpenaiClient._make_openai_request')
 @patch('bitcast.validator.utils.config.DISABLE_LLM_CACHING', True)
-def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
+async def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
                         mock_get_video_analytics, mock_get_video_data, mock_get_all_uploads, 
                         mock_get_channel_analytics, mock_get_channel_data, mock_get_blacklist, mock_build):
     """Test the get_rewards function end-to-end with a single miner and UID 0"""
@@ -507,7 +508,8 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
             }
             
             # Add metrics for each requested metric
-            for key, (metric, dims) in metric_dims.items():
+            for key, metric_config in metric_dims.items():
+                metric, dims = metric_config[0], metric_config[1]  # Extract metric and dims from 5-tuple
                 if dims == "day":
                     if metric == "estimatedMinutesWatched":
                         result[key] = {
@@ -614,12 +616,18 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
     # Create a mock class instance for self parameter
     mock_self = MagicMock()
     
+    # Create mock_query_miner function that returns responses based on UID
+    async def mock_query_miner(self, uid):
+        return responses[uid]
+    
     # Patch get_briefs to return our test briefs
     with patch('bitcast.validator.reward.get_briefs', return_value=briefs) as mock_get_briefs:
         # Create a wrapper around the reward function that resets scored videos between each UID
         with patch('bitcast.validator.reward.reward', side_effect=reward_wrapper):
-            # Call get_rewards
-            result, yt_stats_list = get_rewards(mock_self, uids, responses)
+            # Patch query_miner to return our mock responses
+            with patch('bitcast.validator.reward.query_miner', side_effect=mock_query_miner) as mock_query_miner_patch:
+                # Call get_rewards
+                result, yt_stats_list = await get_rewards(mock_self, uids)
         
         # Verify the result is a numpy array
         assert isinstance(result, np.ndarray)
@@ -647,6 +655,9 @@ def test_get_rewards_single_miner(mock_make_openai_request, mock_get_transcript,
         
         # Verify that get_briefs was called
         mock_get_briefs.assert_called_once()
+        
+        # Verify that query_miner was called for each UID
+        assert mock_query_miner_patch.call_count == 3
         
         # Verify that yt_stats_list is returned
         assert isinstance(yt_stats_list, list)

--- a/tests/validator/test_eco_mode.py
+++ b/tests/validator/test_eco_mode.py
@@ -126,8 +126,10 @@ def test_eco_mode_disabled_continues_despite_early_return():
         mock_publish_date.assert_called_once()
         mock_retention.assert_called_once()
         mock_captions.assert_called_once()
-        mock_transcript.assert_called_once()
-        mock_prompt_injection.assert_called_once()
+        # Note: transcript and prompt injection are NOT called because all_checks_passed is False
+        # This is the new optimized behavior - transcript is only retrieved when all checks pass
+        mock_transcript.assert_not_called()
+        mock_prompt_injection.assert_not_called()
         mock_evaluate.assert_not_called()  # This is still not called because all_checks_passed is False
         
         # Verify result contains expected values


### PR DESCRIPTION
* gather additional video metrics

* remove some of the slowest analytics calls

* update version

* reduce calls to get transcripts and checks for prompt injection when not in eco mode

* fix eco mode test

* ensure that openai cache expiry dates are moved forward at every use

* extend openai cache to last for 3 days