### PR TITLE
[agent:bob] BC-043: Add Semgrep SAST and Dependabot security scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "ci"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,31 @@
+name: Semgrep SAST
+
+on:
+  pull_request:
+    branches: [main, main]
+  push:
+    branches: [main, main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    name: Semgrep Security Scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run Semgrep
+        run: semgrep scan --config auto --config p/python p/security-audit p/owasp-top-ten --error --severity ERROR --sarif --output semgrep-results.sarif .
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+        with:
+          sarif_file: semgrep-results.sarif
+        continue-on-error: true


### PR DESCRIPTION
## BC-043.5 + BC-043.6: Security Scanning (Layer 1)

### Changes
- **Semgrep SAST** (`.github/workflows/semgrep.yml`): Static analysis security testing on all PRs and pushes to main. Uses `p/python p/security-audit p/owasp-top-ten` rulesets. Fails build on ERROR-severity findings. Uploads SARIF to GitHub Security tab.
- **Dependabot** (`.github/dependabot.yml`): Weekly dependency updates for `pip` packages and GitHub Actions. Auto-opens PRs for outdated/vulnerable dependencies.

### Review Layer 1 (CI/CD)
This PR implements the automated security scanning portion of the multi-gate review process:
- SAST via Semgrep (catches code-level vulnerabilities)
- SCA via Dependabot (catches dependency vulnerabilities)

### Notes
- All GitHub Actions are SHA-pinned per org policy
- Semgrep runs in its own container for speed
- Dependabot will start creating update PRs after merge

Part of BC-043: Implement new Kanban workflow — multi-gate review process