### PR TITLE
[agent:bob] BC-047: Fix Semgrep workflow YAML syntax

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,9 +2,9 @@ name: Semgrep SAST
 
 on:
   pull_request:
-    branches: [main, main]
+    branches: [main]
   push:
-    branches: [main, main]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## BC-047: Fix Semgrep workflow YAML syntax

**Problem:** The `branches` array in `.github/workflows/semgrep.yml` contained a duplicate entry (`[main, main]`) in both `pull_request` and `push` triggers, causing GitHub Actions startup_failure.

**Fix:** Changed `branches: [main, main]` → `branches: [main]` in both triggers.

Discovered during BC-043 Layer 4 review.