### PR TITLE
fix: add workflow_dispatch to deploy workflows

### DIFF
--- a/.github/workflows/deploy-youtube-miner.yml
+++ b/.github/workflows/deploy-youtube-miner.yml
@@ -11,6 +11,7 @@ on:
       - 'neurons/miner.py'
       - 'neurons/base/**'
       - 'core/**'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-youtube-validator.yml
+++ b/.github/workflows/deploy-youtube-validator.yml
@@ -11,6 +11,7 @@ on:
       - 'neurons/validator.py'
       - 'neurons/base/**'
       - 'core/**'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `workflow_dispatch` trigger so deploys can be triggered manually from the GitHub Actions tab.