### PR TITLE
fix: pin async-substrate-interface==1.6.4 + bump bt-decode to 0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp==3.13.2
 aiosignal==1.4.0
 annotated-types==0.7.0
 anyio==4.9.0
-async-substrate-interface>=1.4.2
+async-substrate-interface==1.6.4
 asyncstdlib==3.13.1
 attrs==25.3.0
 base58==2.1.1
@@ -11,7 +11,7 @@ bittensor==9.12.2
 bittensor-cli==9.15.3
 bittensor-commit-reveal==0.4.0
 bittensor-wallet==4.0.0
-bt-decode==0.6.0
+bt-decode==0.8.0
 cachetools==5.5.2
 certifi==2025.1.31
 cffi==1.17.1


### PR DESCRIPTION
## Problem

`async-substrate-interface>=1.4.2` was an open-ended floor pin. pip resolves this to 2.2.0 (latest), which has two breaking changes that crash `import bittensor`:

1. **scalecodec/cyscale conflict** — 2.x adds a runtime conflict check that raises `RuntimeError` on import
2. **`ScaleObj` removed** from `async_substrate_interface.types` — bittensor 9.12.2 imports it directly → `ImportError`

This was reported by a miner/validator hitting the error on fresh install.

## Fix

- Pin `async-substrate-interface==1.6.4` (latest compatible 1.x, same as bitcast-x)
- Bump `bt-decode==0.6.0` → `0.8.0` (required by async-substrate-interface 1.6.4)

## Verification

Reproduced the crash with 2.2.0, then verified the fix:
```
pip install -r requirements.txt  ✅ clean install
import bittensor                   ✅ (v9.12.2)
from async_substrate_interface.types import ScaleObj  ✅
from async_substrate_interface import SubstrateInterface  ✅
import bt_decode                   ✅
```

## Context

Same fix already applied to bitcast-x in commit 3cb60e2 (4 May 2026). This PR brings the main neuron repo in line.