### PR TITLE
fix: don't submit success=True when YouTube channel data is None

### DIFF
--- a/bitcast/validator/platforms/youtube/youtube_evaluator.py
+++ b/bitcast/validator/platforms/youtube/youtube_evaluator.py
@@ -107,7 +107,19 @@ class YouTubeEvaluator(PlatformEvaluator):
             
             # Use existing eval_youtube function
             account_stats = eval_youtube(creds, briefs, min_stake)
-            
+
+            # Check if channel data was actually retrieved — eval_youtube
+            # returns early with details=None when YouTube API calls fail
+            # (channel suspended, token expired, etc.). Don't submit these
+            # as successful results to avoid crashing db_ingestion's mapper.
+            yt_account = account_stats.get("yt_account", {})
+            if yt_account.get("details") is None:
+                error_msg = "YouTube channel data not retrieved (API error or token expired)"
+                bt.logging.warning(f"Account {account_id}: {error_msg}")
+                return AccountResult.create_error_result(
+                    account_id, error_msg, briefs
+                )
+
             return AccountResult(
                 account_id=account_id,
                 platform_data=account_stats.get("yt_account", {}),


### PR DESCRIPTION
## Problem

Sentry issue DB_INGESTION-1 — 216 errors since May 26, still ongoing.
https://bitcast.sentry.io/issues/DB_INGESTION-1

When eval_youtube() fails to retrieve channel data (API error, token expired, channel suspended), it returns early with yt_account.details = None. Previously, _process_youtube_account() wrapped this in an AccountResult with success=True, causing db_ingestion's mapper to crash on the None value.

All 216 events are from a single validator hotkey (5DAoDtMxVqtMu2Nd5E7QhPEGXDMgrySvE1b3rRT5ARDhfNNK) that consistently submits empty account data with success: True.

## Fix

In youtube_evaluator.py:_process_youtube_account(), detect the None details case and return an AccountResult.create_error_result() with success=False and a descriptive error message. This way db_ingestion can skip the payload cleanly instead of crashing.

## Companion PR

bitcast-network/db_ingestion — defensive guard in the mapper (defense-in-depth)

Fixes DB_INGESTION-1