### PR TITLE
fix: product placement emission rate to 1/4 of integration

### DIFF
--- a/bitcast/validator/platforms/youtube/main.py
+++ b/bitcast/validator/platforms/youtube/main.py
@@ -327,7 +327,7 @@ def _get_youtube_scaling_factor(brief_format: str) -> float:
         "dedicated": YT_SCALING_FACTOR_DEDICATED,
         "ad-read": YT_SCALING_FACTOR_AD_READ,
         "integration": YT_SCALING_FACTOR_AD_READ,
-        "productPlacement": 133,
+        "productPlacement": 100,
     }
     
     factor = scaling_factors.get(brief_format, YT_SCALING_FACTOR_DEDICATED)
@@ -343,7 +343,7 @@ def _get_lifetime_deduction(brief_format: str) -> float:
         "dedicated": YT_LIFETIME_DEDUCTION,
         "ad-read": YT_LIFETIME_DEDUCTION_AD_READ,
         "integration": YT_LIFETIME_DEDUCTION_AD_READ,
-        "productPlacement": 8,
+        "productPlacement": 6.25,
     }
     return deductions.get(brief_format, YT_LIFETIME_DEDUCTION)
 


### PR DESCRIPTION
## Change
Product Placement scaling factor and lifetime deduction adjusted from ~1/3 to exactly **1/4 of integration**.

| Param | Before (~1/3) | After (1/4) | Integration (ref) |
|-------|--------|-------|--------|
| scaling factor | 133 | **100** | 400 |
| lifetime deduction | 8 | **6.25** | 25 |

At every revenue level, PP payout now equals integration ÷ 4.

## Files
`bitcast/validator/platforms/youtube/main.py` — `_get_youtube_scaling_factor` + `_get_lifetime_deduction` maps.

Mirrors the creator-portal calculator change (separate PR).