### PR TITLE
fix: remove stale scalecodec/bt-decode before pip install (root cause of miner outage)

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -56,6 +56,13 @@ cd "$PROJECT_ROOT"
 
 # Install project dependencies
 pip install --upgrade pip
+
+# Remove packages that were removed in bittensor 10.x and conflict with their replacements.
+# pip install -r requirements.txt does NOT uninstall packages that are no longer listed,
+# so stale scalecodec/bt-decode/bittensor-cli from 9.x will crash bittensor 10.x at import
+# time with: RuntimeError: Conflict detected: 'scalecodec' is installed, conflicts with 'cyscale'.
+pip uninstall -y scalecodec bt-decode bittensor-cli 2>/dev/null || true
+
 pip install -r requirements.txt
 pip install -e .
 


### PR DESCRIPTION
## Problem

All 22 self-hosted miners went offline after PR #156 (bittensor 9→10 upgrade) was merged. The `auto_update.py` mechanism pulled the new code and ran `setup_env.sh`, which does `pip install -r requirements.txt`. However, **pip does not uninstall packages that were removed from requirements.txt**. This left the old `scalecodec` package installed alongside the new `cyscale` replacement (which uses the same namespace), causing a hard crash at import time:

```
RuntimeError: Conflict detected: 'scalecodec' (py-scale-codec) is installed.
This conflicts with 'cyscale', which uses the same namespace.
```

The miner cannot even `import bittensor` — PM2 crash-loops indefinitely. On-chain, all 22 miners show `active: false`.

## Reproduction

1. Created venv with bittensor 9.12.2 (old requirements.txt)
2. Pulled PR #156 code, ran `pip install -r requirements.txt`
3. `pip install` succeeds (exit 0) but leaves `scalecodec==1.2.12` installed
4. `import bittensor` → `RuntimeError: Conflict detected`

## Fix

Explicitly uninstall the three removed packages (`scalecodec`, `bt-decode`, `bittensor-cli`) before `pip install -r requirements.txt`. Verified: after this fix, bittensor 10.3.0 imports cleanly and the miner code loads successfully.

## Impact

Once merged, broken miners will auto-update on their next cycle (10-15 min), pull this fix, and recover automatically.