### PR TITLE
fix: uninstall cyscale alongside scalecodec in setup_env.sh

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -61,7 +61,14 @@ pip install --upgrade pip
 # pip install -r requirements.txt does NOT uninstall packages that are no longer listed,
 # so stale scalecodec/bt-decode/bittensor-cli from 9.x will crash bittensor 10.x at import
 # time with: RuntimeError: Conflict detected: 'scalecodec' is installed, conflicts with 'cyscale'.
-pip uninstall -y scalecodec bt-decode bittensor-cli 2>/dev/null || true
+#
+# IMPORTANT: cyscale installs its compiled .so files INTO the scalecodec/ directory.
+# If we only uninstall 'scalecodec', pip deletes cyscale's files but keeps cyscale's
+# metadata — so the subsequent 'pip install -r requirements.txt' skips reinstalling
+# cyscale, leaving scalecodec/ gutted and 'import bittensor' fails with
+# ModuleNotFoundError: No module named 'scalecodec'. Uninstall cyscale too so it
+# gets cleanly reinstalled.
+pip uninstall -y scalecodec cyscale bt-decode bittensor-cli 2>/dev/null || true
 
 pip install -r requirements.txt
 pip install -e .


### PR DESCRIPTION
## Root cause

`cyscale` (Cython SCALE codec, installed as a dependency of bittensor 10.x) installs its compiled `.so` files **into the `scalecodec/` directory** — the same namespace as the old pure-Python `scalecodec` package.

When `pip uninstall -y scalecodec` runs (as added in PR #157), it deletes files that cyscale had installed there. But pip still considers cyscale "installed" (metadata intact), so the subsequent `pip install -r requirements.txt` **skips reinstalling cyscale**. Result: `scalecodec/` is gutted, and `import bittensor` fails with:

```
ModuleNotFoundError: No module named 'scalecodec'
  File ".../site-packages/bittensor/utils/__init__.py", line 10
```

## Why this wasn't caught in PR #157

Testing was done against an already-clean 10.3.0 venv (`venv_bt10`), not the actual 9.x → 10.x upgrade path. The bug only manifests when uninstalling `scalecodec` from a venv where cyscale has already populated the `scalecodec/` directory.

## Fix

Add `cyscale` to the `pip uninstall` list so it gets cleanly removed and reinstalled:

```diff
-pip uninstall -y scalecodec bt-decode bittensor-cli 2>/dev/null || true
+pip uninstall -y scalecodec cyscale bt-decode bittensor-cli 2>/dev/null || true
```

## Verification

Reproduced the bug by simulating a miner operator's exact recovery steps against a fresh `bittensor 9.12.2` install, then verified the fix resolves it end-to-end:

```
Pre-upgrade: bittensor 9.12.2, scalecodec 1.2.12, cyscale 0.5.0
  → import fails (expected conflict)

Run setup_env.sh fix:
  → pip uninstall -y scalecodec cyscale bt-decode bittensor-cli
  → pip install -r requirements.txt
  → pip install -e .

Post-upgrade:
  bittensor 10.3.0 OK
  scalecodec at: .../site-packages/scalecodec/__init__.py  (cyscale's files)
  Block 8649415: 13/256 active  (metagraph sync OK)
```

## Impact

This affects all miners using auto-update (PR #156 auto-pulled the broken setup_env.sh). Operators who followed PR #157's recovery instructions and ran `pip uninstall -y scalecodec` hit this immediately.

Reported by Gordon Frayne (UID 60) after following PR #157's recovery instructions.