### PR TITLE
chore: require code owner review for workflow changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require @mizu-tx review for any change to GitHub Actions workflows.
+# See Linear SUB-123.
+.github/workflows/ @mizu-tx


### PR DESCRIPTION
Adds a CODEOWNERS rule requiring @mizu-tx review for any change to `.github/workflows/`. Safety gate ahead of granting the bot `workflow` scope.

Linear: SUB-123