### PR TITLE
fix: chown /app after COPY so non-root user can create cache dirs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ COPY core/ core/
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Fix ownership: COPY runs as root, so re-chown so the non-root user can
+# write cache directories (e.g. /app/bitcast/cache/) at runtime.
+RUN chown -R bitcast:bitcast /app
+
 # Bittensor wallet path (non-root)
 ENV BT_WALLET_PATH=/home/bitcast/.bittensor/wallets
 ENV HOME=/home/bitcast


### PR DESCRIPTION
## Problem

The no-code miner (UID 68) is crash-looping in production with PermissionError on /app/bitcast/cache. Affects ALL ~75 no-code creators.

## Fix

Add chown after COPY steps so the non-root user can write cache dirs.