### PR TITLE
fix: deploy workflows not updating ECS service to new task definition

### DIFF
--- a/.github/workflows/deploy-youtube-miner.yml
+++ b/.github/workflows/deploy-youtube-miner.yml
@@ -66,7 +66,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Update task definition
+      - name: Deploy new task definition
         env:
           IMAGE: ${{ needs.build-and-push.outputs.image }}
         run: |
@@ -79,12 +79,12 @@ jobs:
             'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy) |
              .containerDefinitions[0].image = $IMAGE')
 
-          aws ecs register-task-definition --cli-input-json "$NEW_TASK_DEF" > /dev/null
+          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_TASK_DEF" \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
 
-      - name: Force new deployment
-        run: |
           aws ecs update-service \
             --cluster ${{ env.ECS_CLUSTER }} \
             --service ${{ env.TASK_FAMILY }} \
+            --task-definition "$NEW_TASK_DEF_ARN" \
             --force-new-deployment \
             --region ${{ env.AWS_REGION }}

--- a/.github/workflows/deploy-youtube-validator.yml
+++ b/.github/workflows/deploy-youtube-validator.yml
@@ -66,7 +66,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Update task definition
+      - name: Deploy new task definition
         env:
           IMAGE: ${{ needs.build-and-push.outputs.image }}
         run: |
@@ -79,12 +79,12 @@ jobs:
             'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy) |
              .containerDefinitions[0].image = $IMAGE')
 
-          aws ecs register-task-definition --cli-input-json "$NEW_TASK_DEF" > /dev/null
+          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_TASK_DEF" \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
 
-      - name: Force new deployment
-        run: |
           aws ecs update-service \
             --cluster ${{ env.ECS_CLUSTER }} \
             --service ${{ env.TASK_FAMILY }} \
+            --task-definition "$NEW_TASK_DEF_ARN" \
             --force-new-deployment \
             --region ${{ env.AWS_REGION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ COPY core/ core/
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Fix ownership: COPY runs as root, so re-chown so the non-root user can
+# write cache directories (e.g. /app/bitcast/cache/) at runtime.
+RUN chown -R bitcast:bitcast /app
+
 # Bittensor wallet path (non-root)
 ENV BT_WALLET_PATH=/home/bitcast/.bittensor/wallets
 ENV HOME=/home/bitcast


### PR DESCRIPTION
## Problem

Deploy workflows register a new ECS task def revision but never tell the service to use it. `update-service` was missing `--task-definition`, so the service kept running the old revision — silently ignoring every deploy.

This caused the miner to stay down after the Dockerfile chown fix (PR #162).

## Fix

Capture the new task def ARN from `register-task-definition` and pass it to `update-service --task-definition`. Applied to both miner and validator workflows.