### PR TITLE
fix: restore miner axon coldkey support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,12 @@ aiosqlite==0.22.1
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.14.2
-async-substrate-interface==2.0.2
+async-substrate-interface==2.2.1
 asyncstdlib==3.13.3
 attrs==26.1.0
-bittensor==10.3.0
-bittensor-drand==1.3.0
-bittensor-wallet==4.0.1
+bittensor==10.5.0
+bittensor-drand==2.0.0
+bittensor-wallet==4.1.1
 cachetools==5.5.2
 certifi==2026.6.17
 cffi==2.1.0


### PR DESCRIPTION
## Root cause

The no-code miner now starts, but `bittensor-wallet==4.0.1` cannot deserialize the valid `cryptoType: 1` `coldkeypub.txt`. The axon serve call therefore fails even though the process stays alive.

## Change

Upgrade the compatible Bittensor dependency set:
- `bittensor` 10.3.0 → 10.5.0
- `bittensor-wallet` 4.0.1 → 4.1.1
- `bittensor-drand` 1.3.0 → 2.0.0
- `async-substrate-interface` 2.0.2 → 2.2.1

## Verification

- Full dependency resolver: passed
- Clean Docker miner image build: passed
- Image runs as non-root `bitcast`: passed
- Exact in-image dependency versions: passed
- Production-format `cryptoType: 1` coldkey deserialization through `/entrypoint.sh`: passed
- `/app/bitcast/cache` creation as `bitcast`: passed
- Test suite: 294 passed, 4 failed; identical 4 failures reproduced on unchanged `main` under the same environment (no regression)
