### PR TITLE
fix: strip cryptoType in the entrypoint so serve_axon can publish

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,11 +28,54 @@ WALLET_DIR="${WALLET_BASE}/${WALLET_NAME}"
 HOTKEY_DIR="${WALLET_DIR}/hotkeys"
 mkdir -p "${HOTKEY_DIR}"
 
+# bittensor-wallet 4.1+ writes a "cryptoType" field into keyfiles that 4.0.1 —
+# the version this image pins — refuses to parse:
+#   DeserializationError("Failed to parse keyfile data.")
+#
+# This is not cosmetic. serve_axon reads wallet.coldkeypub to build the
+# extrinsic, so an unparseable coldkeypub.txt aborts the serve *after* the axon
+# starts locally. The miner then logs as healthy forever while its on-chain axon
+# still points at whatever address it last published — validators dial the stale
+# address and the miner earns nothing. This has now bitten prod twice: task-def
+# rev 10 (2026-07-29) and rev 12 (2026-08-06, the no-code wallet migration).
+#
+# 4.0.1's format has no cryptoType and assumes SR25519, so dropping a cryptoType
+# of 1 (SR25519) is lossless — it yields the identical ss58 address. Any other
+# value would silently change the key's curve, so refuse rather than guess. A
+# non-JSON (encrypted) keyfile passes through untouched.
+strip_crypto_type() {
+    python3 - "$1" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path) as fh:
+        keyfile = json.load(fh)
+except (OSError, ValueError, UnicodeDecodeError):
+    sys.exit(0)  # encrypted, missing or non-JSON keyfile — leave it alone
+
+crypto_type = keyfile.pop("cryptoType", None)
+if crypto_type is None:
+    sys.exit(0)
+if crypto_type != 1:
+    sys.exit(
+        f"[entrypoint] ERROR: {path} has cryptoType={crypto_type}, expected 1 "
+        "(SR25519). Refusing to strip it — that would change the key's curve."
+    )
+
+with open(path, "w") as fh:
+    json.dump(keyfile, fh)
+print(f"[entrypoint] Stripped cryptoType=1 from {path} for bittensor-wallet 4.0.1")
+PY
+}
+
 # --- Write hotkey (private key) ---
 if [ -n "${HOTKEY_DATA:-}" ]; then
     echo "[entrypoint] Writing hotkey: ${WALLET_NAME}/${HOTKEY_NAME}"
     echo "${HOTKEY_DATA}" | base64 -d > "${HOTKEY_DIR}/${HOTKEY_NAME}"
     chmod 600 "${HOTKEY_DIR}/${HOTKEY_NAME}"
+    strip_crypto_type "${HOTKEY_DIR}/${HOTKEY_NAME}"
 else
     echo "[entrypoint] ERROR: HOTKEY_DATA not set - cannot run without hotkey"
     exit 1
@@ -42,12 +85,14 @@ fi
 if [ -n "${HOTKEYPUB_DATA:-}" ]; then
     echo "${HOTKEYPUB_DATA}" > "${HOTKEY_DIR}/${HOTKEY_NAME}pub.txt"
     chmod 644 "${HOTKEY_DIR}/${HOTKEY_NAME}pub.txt"
+    strip_crypto_type "${HOTKEY_DIR}/${HOTKEY_NAME}pub.txt"
 fi
 
 # --- Write coldkeypub (public address only) ---
 if [ -n "${COLDKEYPUB_DATA:-}" ]; then
     echo "${COLDKEYPUB_DATA}" > "${WALLET_DIR}/coldkeypub.txt"
     chmod 644 "${WALLET_DIR}/coldkeypub.txt"
+    strip_crypto_type "${WALLET_DIR}/coldkeypub.txt"
 fi
 
 # --- Clear sensitive env vars ---


### PR DESCRIPTION
## The no-code YouTube miner is currently off the network

Since **2026-08-06 21:28 UTC**. From the miner's own log, one line after the axon starts:

```
Serving miner axon Axon([::], 8091, 5EnUv29zoq5X..., stopped, [...]) on network: ... netuid: 93
ERROR | Subtensor returned: Failed to get coldkeypub: DeserializationError("Failed to parse keyfile data.")
```

`serve_axon` reads `wallet.coldkeypub` to build the extrinsic, so the serve aborts *after* the local axon is already listening. The miner then looks healthy forever, while the chain still advertises whatever address it last published:

| | |
|---|---|
| chain axon for UID 68 | `100.31.50.117:8091` — a dead earlier Fargate IP |
| actual running task | `98.87.20.205` |

Validators dial `metagraph.axons[uid]`, so they have been reaching nothing for ~10 hours.

## Cause, and why the variable fix isn't enough

`bittensor-wallet` 4.1+ writes a `cryptoType` field into keyfiles that 4.0.1 — the version this image pins — refuses to parse. It arrives through the `COLDKEYPUB_DATA` Terraform variable.

The task-definition history is a clean natural experiment:

| rev | registered | `cryptoType` | outcome |
|---|---|---|---|
| 9 | 07-29 14:04 | present | broken |
| 10 | 07-29 18:12 | present | broken |
| 11 | 07-29 18:53 | **stripped** | served fine for 8 days |
| 12 | 08-06 21:27 | present | broken since |

Rev 11 fixed it by editing the variable. Rev 12 — the no-code wallet migration — regenerated the value and silently re-armed the trap. That is twice now, so this strips the field where the keyfile is *written* rather than relying on whoever next regenerates the variable. Mirrors what `bitcast-x-v2`'s entrypoint already does for its hotkey.

## Safety

Dropping `cryptoType: 1` (SR25519) is lossless — 4.0.1's format has no such field and assumes SR25519. Any other value would change the key's curve, so it **refuses and exits** rather than guessing. Encrypted and non-JSON keyfiles pass through untouched.

## Verification

Ran the patched entrypoint against the **real rev-12 values**, verbatim:

- all three files (hotkey, hotkeypub, coldkeypub) strip cleanly
- `bittensor_wallet.Wallet` then loads `coldkeypub` as `5CZvJqeD…` and `hotkey` as `5GW7U7RU…` — the UID 153 wallet, addresses unchanged
- output matches rev 11's proven-good shape byte for byte
- no-op path (already clean), encrypted-keyfile path, and `cryptoType=2` refusal all verified
- `bash -n` clean

## Note on merging

This repo's `deploy-youtube-miner.yml` builds and deploys on push to `main`, so merging this rebuilds and rolls the miner. That is intended — but it will still come up on the **old UID 68 hotkey** until `bitcast/prod/youtube-miner/HOTKEY_DATA` is updated to the UID 153 private hotkey (that secret is unchanged since 2026-06-06). Sequence the two together.